### PR TITLE
feat: default ChatGPT-subscription GPT models to fast

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Changed ChatGPT/Codex subscription GPT models that support fast mode to default to the `priority` service tier when no preference is saved.
 - Added xAI Grok subscription support: a `grok` OAuth provider with device-code login against accounts.x.ai and a `grok-responses` API that streams through xAI's Grok CLI proxy so SuperGrok / X Premium+ subscriptions cover inference.
 - Added fast mode for Grok 4.5 and Grok 4.6 subscription models, mapping the `priority` service tier to `low` reasoning effort on the same model id.
 - Fixed model-aware reasoning controls to preserve provider defaults and native payload schemas, including authoritative custom Anthropic/Bedrock effort routes, synchronous control-discriminator validation, strict off-budget and fixed-contract validation, non-reasoning payload guards, explicit disable precedence, exact custom contracts, string-only legacy maps, Anthropic gateway passthroughs, Fireworks and Kimi compatible controls, native Moonshot K2 toggles and K3 effort, Bedrock Claude sampling compatibility and Nova 2 Lite effort, Gemini Flash aliases, per-alias OpenRouter and Prime effort routes, documented Copilot controls, native Magistral behavior, and GPT-5 Mini/Nano minimal effort.

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -8,6 +8,7 @@ import type {
 	ModelThinkingLevel,
 	OpenAICompletionsCompat,
 	ReasoningEffortLevelMap,
+	ServiceTier,
 	ThinkingLevelMap,
 	ThinkingLevelValue,
 	Usage,
@@ -64,6 +65,14 @@ export function supportsFastMode<TApi extends Api>(model: Model<TApi>): boolean 
 		model.api === "openai-codex-responses" &&
 		(model.id === "gpt-5.4" || model.id === "gpt-5.5" || model.id === "gpt-5.6" || model.id.startsWith("gpt-5.6-"))
 	);
+}
+
+/** Default service tier when the user has not saved a preference. */
+export function defaultServiceTierForModel<TApi extends Api>(model: Model<TApi> | undefined | null): ServiceTier {
+	if (model && model.provider === "openai-codex" && supportsFastMode(model)) {
+		return "priority";
+	}
+	return "default";
 }
 
 export interface CostOverrides {

--- a/packages/ai/test/fast-mode.test.ts
+++ b/packages/ai/test/fast-mode.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { supportsFastMode } from "../src/models.js";
+import { defaultServiceTierForModel, supportsFastMode } from "../src/models.js";
 import { buildBaseOptions } from "../src/providers/simple-options.js";
 import type { Api, Model } from "../src/types.js";
 
@@ -32,5 +32,18 @@ describe("Fast mode", () => {
 	it("forwards priority through simple stream options", () => {
 		const testModel = model("openai-codex", "gpt-5.5", "openai-codex-responses");
 		expect(buildBaseOptions(testModel, { serviceTier: "priority" }).serviceTier).toBe("priority");
+	});
+
+	it.each(["gpt-5.4", "gpt-5.5", "gpt-5.6-sol", "gpt-5.6-luna"])("defaults ChatGPT-auth %s to priority", (id) => {
+		expect(defaultServiceTierForModel(model("openai-codex", id, "openai-codex-responses"))).toBe("priority");
+	});
+
+	it("does not default API-key GPT or Grok models to priority", () => {
+		expect(defaultServiceTierForModel(model("openai", "gpt-5.5", "openai-responses"))).toBe("default");
+		expect(defaultServiceTierForModel(model("openai-codex", "gpt-5.3-codex", "openai-codex-responses"))).toBe(
+			"default",
+		);
+		expect(defaultServiceTierForModel(model("grok", "grok-4.5", "grok-responses"))).toBe("default");
+		expect(defaultServiceTierForModel(undefined)).toBe("default");
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed the agents view failing to refresh heartbeats forever once any session worker entered the terminal failed state; failed workers are now skipped when aggregating heartbeats.
 - Added xAI Grok subscription login via `/login`, letting SuperGrok and X Premium+ subscribers use Grok models under the new `grok` provider without an xAI API key.
 - Added `/fast` support for Grok 4.5 and Grok 4.6 under the `grok` provider, running the same model at low reasoning effort.
 - Changed reasoning controls to be model-aware across the UI and provider payloads, with authoritative Anthropic/Bedrock effort routes, synchronous control-discriminator validation, strict native off-budget and fixed-contract validation, exact custom-provider contracts, native Moonshot controls, and string-only legacy thinking maps.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Changed ChatGPT subscription GPT models that support `/fast` (GPT-5.4, GPT-5.5, GPT-5.6) to default to fast mode when no service-tier preference is saved.
 - Fixed the agents view failing to refresh heartbeats forever once any session worker entered the terminal failed state; failed workers are now skipped when aggregating heartbeats.
 - Added xAI Grok subscription login via `/login`, letting SuperGrok and X Premium+ subscribers use Grok models under the new `grok` provider without an xAI API key.
 - Added `/fast` support for Grok 4.5 and Grok 4.6 under the `grok` provider, running the same model at low reasoning effort.

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -1,6 +1,13 @@
 import { join } from "node:path";
 import { Agent, type AgentMessage, type ThinkingLevel } from "@earendil-works/pi-agent-core";
-import { clampThinkingLevel, type Message, type Model, streamSimple, supportsFastMode } from "@earendil-works/pi-ai";
+import {
+	clampThinkingLevel,
+	defaultServiceTierForModel,
+	type Message,
+	type Model,
+	streamSimple,
+	supportsFastMode,
+} from "@earendil-works/pi-ai";
 import { getAgentDir } from "../config.js";
 import { AgentSession } from "./agent-session.js";
 import type { AgentSessionCreationOptions } from "./agent-session-services.js";
@@ -244,7 +251,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 	const serviceTierPreference =
 		options.serviceTier ??
-		(hasServiceTierEntry ? existingSession.serviceTier : settingsManager.getDefaultServiceTier());
+		(hasServiceTierEntry
+			? existingSession.serviceTier
+			: (settingsManager.getConfiguredDefaultServiceTier() ?? defaultServiceTierForModel(model)));
 	const serviceTier =
 		serviceTierPreference === "priority" && (!model || !supportsFastMode(model)) ? "default" : serviceTierPreference;
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -762,6 +762,10 @@ export class SettingsManager {
 		return this.settings.defaultServiceTier ?? "default";
 	}
 
+	getConfiguredDefaultServiceTier(): ServiceTier | undefined {
+		return this.settings.defaultServiceTier;
+	}
+
 	setDefaultServiceTier(serviceTier: ServiceTier): void {
 		this.globalSettings.defaultServiceTier = serviceTier;
 		this.markModified("defaultServiceTier");

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1732,7 +1732,13 @@ export class DaemonSupervisor {
 					const match = await this.findWorkerForClient(client, command.activeSessionId);
 					return this.forwardToWorker(match.worker, command);
 				}
-				const workers = [...this.workers.values()].filter((worker) => this.isLiveWorker(worker));
+				// A "failed" lifecycle is terminal (recovery retries exhausted), so a
+				// failed worker can neither serve the command nor run its heartbeats.
+				// Including it would fail every aggregate refresh forever; transient
+				// states (starting/recovering) still block to avoid partial catalogs.
+				const workers = [...this.workers.values()].filter(
+					(worker) => this.isLiveWorker(worker) && worker.descriptor.lifecycle !== "failed",
+				);
 				const heartbeats = new Map<string, AgentConnectionHeartbeat>();
 				const snapshots: Array<{
 					heartbeats?: AgentConnectionHeartbeat[];

--- a/packages/coding-agent/test/daemon-supervisor-heartbeats.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-heartbeats.test.ts
@@ -30,7 +30,7 @@ function createSupervisorHarness(): SupervisorHarness {
 	}) as unknown as SupervisorHarness;
 }
 
-function worker(lifecycle: "ready" | "recovering", connected = true) {
+function worker(lifecycle: "ready" | "recovering" | "failed", connected = true) {
 	return {
 		descriptor: { lifecycle },
 		...(connected ? { client: {} } : {}),
@@ -135,6 +135,32 @@ describe("daemon supervisor heartbeat aggregation", () => {
 		expect(response).toMatchObject({
 			success: false,
 			error: "Cannot list heartbeats while session worker is recovering",
+		});
+		expect(supervisor.forwardToWorker).toHaveBeenCalledOnce();
+	});
+
+	it("skips terminally failed workers instead of failing the aggregate", async () => {
+		const supervisor = createSupervisorHarness();
+		const healthy = worker("ready");
+		const failed = {
+			...worker("failed", false),
+			heartbeatSnapshot: [{ job: { id: "heartbeat-dead" } }],
+			heartbeatSnapshotStale: false,
+		};
+		supervisor.workers.set("healthy", healthy);
+		supervisor.workers.set("failed", failed);
+		supervisor.forwardToWorker = vi.fn(async (_target, command) =>
+			success(command.id, command.type, { heartbeats: [{ job: { id: "heartbeat-1" } }] }),
+		);
+
+		const response = await supervisor.handleCommand({} as DaemonSocketClient, {
+			id: "list-failed",
+			type: "heartbeats_list",
+		});
+
+		expect(response).toMatchObject({
+			success: true,
+			data: { heartbeats: [{ job: { id: "heartbeat-1" } }] },
 		});
 		expect(supervisor.forwardToWorker).toHaveBeenCalledOnce();
 	});

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -8,7 +8,7 @@ import { join } from "node:path";
 import type { AgentMessage, AgentTool } from "@earendil-works/pi-agent-core";
 import { Agent } from "@earendil-works/pi-agent-core";
 import type { FauxModelDefinition, FauxProviderRegistration, FauxResponseStep, Model } from "@earendil-works/pi-ai";
-import { registerFauxProvider } from "@earendil-works/pi-ai";
+import { defaultServiceTierForModel, registerFauxProvider } from "@earendil-works/pi-ai";
 import type { AgentSessionMessageController } from "../../src/core/agent-messages.js";
 import type { AgentObserveController } from "../../src/core/agent-observe.js";
 import { AgentSession, type AgentSessionEvent, type AutoRefineReviewer } from "../../src/core/agent-session.js";
@@ -159,6 +159,7 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 		initialState: {
 			model,
 			systemPrompt: options.systemPrompt ?? "You are a test assistant.",
+			serviceTier: defaultServiceTierForModel(model),
 			tools: [],
 		},
 		convertToLlm,
@@ -192,10 +193,14 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 	const resourceLoader =
 		options.resourceLoader ?? createTestResourceLoader(extensionsResult ? { extensionsResult } : undefined);
 
+	const serviceTier = defaultServiceTierForModel(model);
+	sessionManager.appendServiceTierChange(serviceTier);
+
 	const session = new AgentSession({
 		agent,
 		sessionManager,
 		settingsManager,
+		serviceTierPreference: serviceTier,
 		cwd: tempDir,
 		modelRegistry,
 		resourceLoader,

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -79,6 +79,7 @@ export interface HarnessOptions {
 	autoRefineReviewer?: AutoRefineReviewer;
 	serializedRefine?: boolean;
 	initialGoal?: { objective: string; tokenBudget?: number };
+	scopedModels?: boolean;
 }
 
 export interface Harness {
@@ -215,6 +216,7 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 		autoRefineReviewer: options.autoRefineReviewer,
 		serializedRefine: options.serializedRefine,
 		initialGoal: options.initialGoal,
+		scopedModels: options.scopedModels ? fauxProvider.models.map((model) => ({ model })) : undefined,
 	});
 
 	const events: AgentSessionEvent[] = [];

--- a/packages/coding-agent/test/suite/regressions/4620-fast-mode-settings.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4620-fast-mode-settings.test.ts
@@ -120,6 +120,7 @@ describe("ENG-4620 fast mode settings", () => {
 			api: "openai-codex-responses",
 			provider: "openai-codex",
 			models: [{ id: "gpt-5.4" }, { id: "gpt-5.3" }],
+			scopedModels: true,
 		});
 
 		harness.session.setServiceTier("priority");

--- a/packages/coding-agent/test/suite/regressions/4620-fast-mode-settings.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4620-fast-mode-settings.test.ts
@@ -19,6 +19,40 @@ describe("ENG-4620 fast mode settings", () => {
 		harness = undefined;
 	});
 
+	it("defaults ChatGPT-auth GPT models to fast when no preference is saved", async () => {
+		harness = await createHarness({
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			models: [{ id: "gpt-5.6-sol" }],
+		});
+
+		expect(harness.settingsManager.getConfiguredDefaultServiceTier()).toBeUndefined();
+		expect(harness.session.serviceTier).toBe("priority");
+	});
+
+	it("keeps an explicit default preference over the ChatGPT-auth fast default", async () => {
+		harness = await createHarness({
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			models: [{ id: "gpt-5.6-sol" }],
+		});
+		const currentHarness = harness;
+
+		currentHarness.session.setServiceTier("default");
+		expect(currentHarness.settingsManager.getDefaultServiceTier()).toBe("default");
+
+		const { session } = await createAgentSession({
+			cwd: currentHarness.tempDir,
+			authStorage: currentHarness.authStorage,
+			model: currentHarness.getModel(),
+			resourceLoader: createTestResourceLoader(),
+			sessionManager: SessionManager.inMemory(currentHarness.tempDir),
+			settingsManager: currentHarness.settingsManager,
+		});
+		sessions.push(session);
+		expect(session.serviceTier).toBe("default");
+	});
+
 	it("uses the saved fast mode preference for new sessions", async () => {
 		harness = await createHarness({
 			api: "openai-codex-responses",
@@ -27,6 +61,7 @@ describe("ENG-4620 fast mode settings", () => {
 		});
 		const currentHarness = harness;
 
+		currentHarness.session.setServiceTier("default");
 		currentHarness.session.setServiceTier("priority");
 		expect(currentHarness.settingsManager.getDefaultServiceTier()).toBe("priority");
 
@@ -69,6 +104,7 @@ describe("ENG-4620 fast mode settings", () => {
 			models: [{ id: "gpt-5.4" }, { id: "gpt-5.3" }],
 		});
 
+		harness.session.setServiceTier("default");
 		harness.session.setServiceTier("priority");
 		await harness.session.setModel(harness.getModel("gpt-5.3")!);
 


### PR DESCRIPTION
## Summary
- ChatGPT/Codex OAuth (`openai-codex`) GPT models that support `/fast` (GPT-5.4, 5.5, 5.6 including sol/luna/terra) now default to the `priority` service tier when the user has not saved a service-tier preference.
- An explicit saved preference (`default` or `priority`) still wins. API-key OpenAI models, Grok, and Codex models that do not support fast mode stay on `default`.

## Test plan
- [x] `packages/ai` `test/fast-mode.test.ts`
- [x] `packages/coding-agent` `4620-fast-mode-settings.test.ts` (plus sibling 4620 fast-mode tests)
- [x] `npm run check`