### PR TITLE
test: fix stale CI assertions against current contracts

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed Grok OAuth tokens issued with `expires_in` of five minutes or less expiring at issuance by clamping the expiry skew to half the token lifetime.
 - Changed ChatGPT/Codex subscription GPT models that support fast mode to default to the `priority` service tier when no preference is saved.
 - Added xAI Grok subscription support: a `grok` OAuth provider with device-code login against accounts.x.ai and a `grok-responses` API that streams through xAI's Grok CLI proxy so SuperGrok / X Premium+ subscriptions cover inference.
 - Added fast mode for Grok 4.5 and Grok 4.6 subscription models, mapping the `priority` service tier to `low` reasoning effort on the same model id.

--- a/packages/ai/src/utils/oauth/grok.ts
+++ b/packages/ai/src/utils/oauth/grok.ts
@@ -171,10 +171,15 @@ function credentialsFromTokenResponse(data: TokenResponse, previousRefreshToken?
 			? data.expires_in
 			: DEFAULT_ACCESS_TOKEN_LIFETIME_SECONDS;
 
+	// The skew must never consume the whole lifetime: a token issued with
+	// expires_in <= 300s would otherwise be born expired and refresh on first use.
+	const lifetimeMs = expiresIn * 1000;
+	const skewMs = Math.min(TOKEN_EXPIRY_SKEW_MS, lifetimeMs / 2);
+
 	return {
 		refresh,
 		access: data.access_token,
-		expires: Date.now() + expiresIn * 1000 - TOKEN_EXPIRY_SKEW_MS,
+		expires: Date.now() + lifetimeMs - skewMs,
 	};
 }
 

--- a/packages/ai/test/github-copilot-anthropic.test.ts
+++ b/packages/ai/test/github-copilot-anthropic.test.ts
@@ -96,6 +96,7 @@ describe("Copilot Claude via Anthropic Messages", () => {
 		const { streamAnthropic } = await import("../src/providers/anthropic.js");
 		const s = streamAnthropic(model, context, {
 			apiKey: "tid_copilot_session_test_token",
+			thinkingEnabled: true,
 			interleavedThinking: true,
 		});
 		for await (const event of s) {

--- a/packages/ai/test/grok-oauth.test.ts
+++ b/packages/ai/test/grok-oauth.test.ts
@@ -388,6 +388,23 @@ describe("xAI Grok OAuth token refresh", () => {
 		expect(credentials.refresh).toBe("old-refresh");
 	});
 
+	it.each([300, 301])("keeps a %is token usable past issuance instead of expiring immediately", async (expiresIn) => {
+		vi.useFakeTimers();
+		const startTime = new Date("2026-03-09T00:00:00Z");
+		vi.setSystemTime(startTime);
+
+		const fetchMock = vi.fn(async (): Promise<Response> => {
+			return jsonResponse({ access_token: "short-access", refresh_token: "new-refresh", expires_in: expiresIn });
+		});
+
+		vi.stubGlobal("fetch", fetchMock);
+
+		const credentials = await refreshGrokToken("old-refresh");
+		const lifetimeMs = expiresIn * 1000;
+		expect(credentials.expires).toBe(startTime.getTime() + lifetimeMs - lifetimeMs / 2);
+		expect(credentials.expires).toBeGreaterThan(startTime.getTime());
+	});
+
 	it("fails clearly when no refresh token is stored", async () => {
 		await expect(refreshGrokToken("")).rejects.toThrow(/refresh token/);
 	});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed daemon session workers being left running when launch failed before a process identity was captured.
 - Fixed daemon supervisor registry setup treating a non-directory path as a registry instead of rejecting it.
+- Fixed daemon supervisor registries created under a shared temp directory inheriting umask `0755` and failing the private-directory check.
 - Changed ChatGPT subscription GPT models that support `/fast` (GPT-5.4, GPT-5.5, GPT-5.6) to default to fast mode when no service-tier preference is saved.
 - Fixed the agents view failing to refresh heartbeats forever once any session worker entered the terminal failed state; failed workers are now skipped when aggregating heartbeats.
 - Added xAI Grok subscription login via `/login`, letting SuperGrok and X Premium+ subscribers use Grok models under the new `grok` provider without an xAI API key.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed daemon startup fencing inspecting the ambient default registry instead of the selected supervisor registry.
 - Fixed daemon session workers being left running when launch failed before a process identity was captured.
 - Fixed daemon supervisor registry setup treating a non-directory path as a registry instead of rejecting it.
 - Fixed daemon supervisor registries created under a shared temp directory inheriting umask `0755` and failing the private-directory check.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Fixed daemon supervisor registry setup treating a non-directory path as a registry instead of rejecting it.
 - Fixed daemon supervisor registries created under a shared temp directory inheriting umask `0755` and failing the private-directory check.
 - Fixed forced worker stop reporting a partial process-tree failure before detecting that the stop had been relaunched or rescinded.
+- Fixed `--version` and `--help` writing to stderr in non-TTY launches after stdout takeover.
+- Fixed explicit daemon shutdown leaving resident session files active instead of archived.
 - Changed ChatGPT subscription GPT models that support `/fast` (GPT-5.4, GPT-5.5, GPT-5.6) to default to fast mode when no service-tier preference is saved.
 - Fixed the agents view failing to refresh heartbeats forever once any session worker entered the terminal failed state; failed workers are now skipped when aggregating heartbeats.
 - Added xAI Grok subscription login via `/login`, letting SuperGrok and X Premium+ subscribers use Grok models under the new `grok` provider without an xAI API key.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed daemon supervisor registry validation rejecting macOS temp paths outside the process temp boundary because `/var` is a symlink, which prevented startup with a selected registry under an insecure ambient temp.
 - Fixed daemon startup fencing inspecting the ambient default registry instead of the selected supervisor registry.
 - Fixed the IPython kernel startup timing out on slow or loaded runners before it could answer the readiness probe.
 - Fixed daemon session workers being left running when launch failed before a process identity was captured.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,7 +6,9 @@
 - Fixed daemon supervisor registry setup treating a non-directory path as a registry instead of rejecting it.
 - Fixed daemon supervisor registries created under a shared temp directory inheriting umask `0755` and failing the private-directory check.
 - Fixed forced worker stop reporting a partial process-tree failure before detecting that the stop had been relaunched or rescinded.
-- Fixed `--version` and `--help` writing to stderr in non-TTY launches after stdout takeover.
+- Fixed `--version` printing to stdout before non-interactive stdout takeover, while keeping `--help` on stderr in json and print modes.
+- Fixed daemon shutdown and restart closing the client socket before the success response was written.
+- Fixed Windows shell resolution selecting the WSL System32 bash.exe launcher when Git Bash is not installed.
 - Fixed explicit daemon shutdown leaving resident session files active instead of archived.
 - Changed ChatGPT subscription GPT models that support `/fast` (GPT-5.4, GPT-5.5, GPT-5.6) to default to fast mode when no service-tier preference is saved.
 - Fixed the agents view failing to refresh heartbeats forever once any session worker entered the terminal failed state; failed workers are now skipped when aggregating heartbeats.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed daemon session workers being left running when launch failed before a process identity was captured.
+- Fixed daemon supervisor registry setup treating a non-directory path as a registry instead of rejecting it.
 - Changed ChatGPT subscription GPT models that support `/fast` (GPT-5.4, GPT-5.5, GPT-5.6) to default to fast mode when no service-tier preference is saved.
 - Fixed the agents view failing to refresh heartbeats forever once any session worker entered the terminal failed state; failed workers are now skipped when aggregating heartbeats.
 - Added xAI Grok subscription login via `/login`, letting SuperGrok and X Premium+ subscribers use Grok models under the new `grok` provider without an xAI API key.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed `--version` printing to stdout before non-interactive stdout takeover, while keeping `--help` on stderr in json and print modes.
 - Fixed daemon shutdown and restart closing the client socket before the success response was written.
 - Fixed Windows shell resolution selecting the WSL System32 bash.exe launcher when Git Bash is not installed.
+- Fixed PowerShell shell detection treating Windows `pwsh.exe` paths as non-PowerShell on non-Windows hosts.
 - Fixed explicit daemon shutdown leaving resident session files active instead of archived.
 - Changed ChatGPT subscription GPT models that support `/fast` (GPT-5.4, GPT-5.5, GPT-5.6) to default to fast mode when no service-tier preference is saved.
 - Fixed the agents view failing to refresh heartbeats forever once any session worker entered the terminal failed state; failed workers are now skipped when aggregating heartbeats.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed daemon session workers being left running when launch failed before a process identity was captured.
 - Fixed daemon supervisor registry setup treating a non-directory path as a registry instead of rejecting it.
 - Fixed daemon supervisor registries created under a shared temp directory inheriting umask `0755` and failing the private-directory check.
+- Fixed forced worker stop reporting a partial process-tree failure before detecting that the stop had been relaunched or rescinded.
 - Changed ChatGPT subscription GPT models that support `/fast` (GPT-5.4, GPT-5.5, GPT-5.6) to default to fast mode when no service-tier preference is saved.
 - Fixed the agents view failing to refresh heartbeats forever once any session worker entered the terminal failed state; failed workers are now skipped when aggregating heartbeats.
 - Added xAI Grok subscription login via `/login`, letting SuperGrok and X Premium+ subscribers use Grok models under the new `grok` provider without an xAI API key.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed daemon startup fencing inspecting the ambient default registry instead of the selected supervisor registry.
+- Fixed the IPython kernel startup timing out on slow or loaded runners before it could answer the readiness probe.
 - Fixed daemon session workers being left running when launch failed before a process identity was captured.
 - Fixed daemon supervisor registry setup treating a non-directory path as a registry instead of rejecting it.
 - Fixed daemon supervisor registries created under a shared temp directory inheriting umask `0755` and failing the private-directory check.

--- a/packages/coding-agent/docs/windows.md
+++ b/packages/coding-agent/docs/windows.md
@@ -59,7 +59,7 @@ Prime Agent resolves a project shell in this order:
 
 1. `shellPath` in `~/.prime/agent/settings.json`
 2. Git Bash in its standard installation locations
-3. `bash.exe` on `PATH` (MSYS2, Cygwin, or WSL)
+3. `bash.exe` on `PATH` (MSYS2, Cygwin, or Git Bash). The WSL launcher at `%SystemRoot%\System32\bash.exe` is skipped.
 4. PowerShell 7 (`pwsh`)
 5. Windows PowerShell (`powershell.exe`)
 

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -27,7 +27,8 @@ import {
 const DELIM = Buffer.from("<IDS|MSG>");
 const PROTOCOL_VERSION = "5.3";
 const PORTS_RESOLVE_TIMEOUT_MS = 5000;
-const READY_TIMEOUT_MS = 5000;
+// CI runners can take >5s to cold-start an ipykernel over TCP.
+const READY_TIMEOUT_MS = 30_000;
 // Loopback PUB/SUB subscription propagation is usually sub-ms, but keep a small guard before first execute.
 const IOPUB_SUBSCRIBE_DELAY_MS = 50;
 const DEFAULT_MAX_OUTPUT_CHARS = 65536;

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1075,10 +1075,6 @@ export async function main(args: string[], options?: MainOptions) {
 		console.log(VERSION);
 		process.exit(0);
 	}
-	if (parsed.help) {
-		console.log(formatTopLevelHelp());
-		process.exit(0);
-	}
 	const appMode = resolveAppMode(parsed, process.stdin.isTTY);
 
 	if (shouldRejectNonInteractiveAttach(publicCommand.attachAgent, appMode)) {
@@ -1095,6 +1091,10 @@ export async function main(args: string[], options?: MainOptions) {
 	const shouldTakeOverStdout = appMode !== "interactive";
 	if (shouldTakeOverStdout) {
 		takeOverStdout();
+	}
+	if (parsed.help) {
+		console.log(formatTopLevelHelp());
+		process.exit(0);
 	}
 
 	if (parsed.export) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1071,6 +1071,14 @@ export async function main(args: string[], options?: MainOptions) {
 		}
 	}
 	time("parseArgs");
+	if (parsed.version) {
+		console.log(VERSION);
+		process.exit(0);
+	}
+	if (parsed.help) {
+		console.log(formatTopLevelHelp());
+		process.exit(0);
+	}
 	const appMode = resolveAppMode(parsed, process.stdin.isTTY);
 
 	if (shouldRejectNonInteractiveAttach(publicCommand.attachAgent, appMode)) {
@@ -1087,15 +1095,6 @@ export async function main(args: string[], options?: MainOptions) {
 	const shouldTakeOverStdout = appMode !== "interactive";
 	if (shouldTakeOverStdout) {
 		takeOverStdout();
-	}
-
-	if (parsed.version) {
-		console.log(VERSION);
-		process.exit(0);
-	}
-	if (parsed.help) {
-		console.log(formatTopLevelHelp());
-		process.exit(0);
 	}
 
 	if (parsed.export) {

--- a/packages/coding-agent/src/modes/daemon/daemon-socket.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-socket.ts
@@ -147,7 +147,9 @@ function readWindowsDaemonSocketCandidates(
 				hasLiveResidentWorkers: hasLiveResidentWorker(descriptorDir, config.socketPath),
 				hasLiveListener: isWindowsNamedPipePresent(config.socketPath),
 			});
-		} catch {}
+		} catch {
+			// Skip unreadable or corrupt supervisor descriptors during discovery.
+		}
 	}
 	return candidates;
 }
@@ -213,7 +215,9 @@ function hasLiveResidentWorker(descriptorDir: string, supervisorSocketPath: stri
 			) {
 				return true;
 			}
-		} catch {}
+		} catch {
+			// Skip unreadable or corrupt worker descriptors when probing liveness.
+		}
 	}
 	return false;
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import {
+	chmodSync,
 	closeSync,
 	existsSync,
 	fsyncSync,
@@ -620,6 +621,11 @@ async function withDaemonSupervisorRegistryGuard<T>(registryDir: string, action:
 	}
 }
 
+function mkdirPrivateDaemonSupervisorDir(directory: string, recursive = false): void {
+	mkdirSync(directory, { recursive, mode: 0o700 });
+	chmodSync(directory, 0o700);
+}
+
 function ensureSecureDaemonSupervisorRegistryDir(
 	registryDir: string,
 	create: boolean,
@@ -632,7 +638,7 @@ function ensureSecureDaemonSupervisorRegistryDir(
 	}
 	if (process.platform === "win32") {
 		if (create) {
-			mkdirSync(registryDir, { recursive: true, mode: 0o700 });
+			mkdirPrivateDaemonSupervisorDir(registryDir, true);
 		}
 		return undefined;
 	}
@@ -659,7 +665,7 @@ function ensureSecureDaemonSupervisorRegistryDir(
 			if ((error as NodeJS.ErrnoException).code !== "ENOENT" || !create || directory === root) {
 				throw error;
 			}
-			mkdirSync(directory, { mode: 0o700 });
+			mkdirPrivateDaemonSupervisorDir(directory);
 		}
 		const metadata = lstatSync(directory);
 		if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
@@ -824,7 +830,7 @@ export async function acquireDaemonSupervisorOwnership(
 	try {
 		await withDaemonSupervisorRegistryGuards([...admissionRegistryDirs, ...discoveryRegistryDirs], () => {
 			for (const registration of registrations) {
-				mkdirSync(registration.candidateDirectory, { mode: 0o700 });
+				mkdirPrivateDaemonSupervisorDir(registration.candidateDirectory);
 				writeOwnerScope(registration.candidateDirectory, record);
 				writeOwnerRecord(registration.candidateDirectory, record);
 			}
@@ -1191,7 +1197,7 @@ export async function persistDaemonStartupFenceFromOwner(
 	const fenceDirectory = resolve(authoritativeRegistryDir, "startup-fences");
 	const path = startupFencePath(fenceDirectory, socketPath);
 	await withDaemonSupervisorRegistryGuard(authoritativeRegistryDir, () => {
-		mkdirSync(fenceDirectory, { recursive: true, mode: 0o700 });
+		mkdirPrivateDaemonSupervisorDir(fenceDirectory, true);
 		const record: DaemonStartupFenceRecord = {
 			version: OWNER_VERSION,
 			token: randomUUID(),
@@ -1328,7 +1334,7 @@ export async function adoptLegacyDaemonSupervisorOwnershipFromHello(
 		}
 		if (!existingAuthoritative) {
 			const candidateDirectory = resolve(targetRegistryDir, `.candidate-${process.pid}-${randomUUID()}`);
-			mkdirSync(candidateDirectory, { mode: 0o700 });
+			mkdirPrivateDaemonSupervisorDir(candidateDirectory);
 			try {
 				writeOwnerScope(candidateDirectory, upgraded);
 				writeOwnerRecord(candidateDirectory, upgraded);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -624,6 +624,12 @@ function ensureSecureDaemonSupervisorRegistryDir(
 	registryDir: string,
 	create: boolean,
 ): UnixRegistryPathIdentity[] | undefined {
+	if (existsSync(registryDir)) {
+		const existing = lstatSync(registryDir);
+		if (existing.isSymbolicLink() || !existing.isDirectory()) {
+			throw new Error(`Insecure daemon supervisor registry path: ${registryDir}`);
+		}
+	}
 	if (process.platform === "win32") {
 		if (create) {
 			mkdirSync(registryDir, { recursive: true, mode: 0o700 });

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -706,7 +706,9 @@ function resolveUnixRegistryPathForValidation(registryDir: string, uid: number):
 		relativeToTemp === "" ||
 		(!relativeToTemp.startsWith(`..${sep}`) && relativeToTemp !== ".." && !isAbsolute(relativeToTemp));
 	if (!isWithinTrustedTemp) {
-		return resolvedRegistryDir;
+		// Resolve symlinked ancestors (e.g. /var on macOS) so the security walk below
+		// validates the physical chain; the temp branch gets the same via realpath.
+		return canonicalizeDaemonFilesystemPath(resolvedRegistryDir);
 	}
 	const tempRoot = parse(trustedTempBoundary).root;
 	const tempSuffix = trustedTempBoundary.slice(tempRoot.length).split(/[\\/]/u).filter(Boolean);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -433,12 +433,16 @@ class DaemonShutdownAdmission {
 	}
 }
 
-function defaultDaemonSupervisorRegistryDir(environment: NodeJS.ProcessEnv = process.env): string {
+export function resolveDaemonSupervisorRegistryDir(environment: NodeJS.ProcessEnv = process.env): string {
 	return (
 		environment[DAEMON_SUPERVISOR_SELECTED_REGISTRY_DIR_ENV] ??
 		environment[DAEMON_SUPERVISOR_REGISTRY_DIR_ENV] ??
 		platformDefaultDaemonSupervisorRegistryDir(environment)
 	);
+}
+
+function defaultDaemonSupervisorRegistryDir(environment: NodeJS.ProcessEnv = process.env): string {
+	return resolveDaemonSupervisorRegistryDir(environment);
 }
 
 function platformDefaultDaemonSupervisorRegistryDir(environment: NodeJS.ProcessEnv = process.env): string {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -4988,8 +4988,6 @@ export class DaemonSupervisor {
 				const result = await terminateUnixProcessGroupByIdentity(entryPid, entryStartId, getProcessStartId);
 				exactTreeTerminationFailed = result === "failed";
 				sigkillSent = result === "terminated";
-			} else {
-				exactTreeTerminationFailed = true;
 			}
 			const forceDeadline = Date.now() + 1000;
 			while (isWorkerProcessAlive() && Date.now() < forceDeadline) {
@@ -4997,6 +4995,7 @@ export class DaemonSupervisor {
 			}
 		}
 		if (exactTreeTerminationFailed) {
+			assertStopStillApplies();
 			worker.intentionalStop = worker.descriptor.stopRequestedAt !== undefined;
 			if (removeDescriptor) {
 				this.scheduleWorkerStopFinalization(worker);
@@ -5006,6 +5005,7 @@ export class DaemonSupervisor {
 			);
 		}
 		if (isWorkerProcessAlive()) {
+			assertStopStillApplies();
 			worker.intentionalStop = worker.descriptor.stopRequestedAt !== undefined;
 			if (removeDescriptor) {
 				this.scheduleWorkerStopFinalization(worker);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -115,6 +115,7 @@ import {
 	DAEMON_SUPERVISOR_REGISTRY_DIR_ENV,
 	DAEMON_SUPERVISOR_SELECTED_REGISTRY_DIR_ENV,
 	isDaemonShutdownAdmissionActive,
+	resolveDaemonSupervisorRegistryDir,
 	waitForDaemonStartupFence,
 } from "./daemon-supervisor-ownership.js";
 import { DaemonWorkerClient } from "./daemon-worker-client.js";
@@ -666,7 +667,10 @@ export class DaemonSupervisor {
 				throw new Error("Daemon supervisor config is missing agentDir");
 			}
 			this.socketLease = await acquireDaemonSocketPathLease(this.socketPath);
-			await waitForDaemonStartupFence(this.socketPath);
+			const supervisorRegistryDir = resolveDaemonSupervisorRegistryDir();
+			const selectedRegistryDir =
+				process.env[DAEMON_SUPERVISOR_SELECTED_REGISTRY_DIR_ENV] ?? process.env[DAEMON_SUPERVISOR_REGISTRY_DIR_ENV];
+			await waitForDaemonStartupFence(this.socketPath, 10_000, supervisorRegistryDir);
 			this.ownership = await acquireDaemonSupervisorOwnership({
 				socketPath: this.socketPath,
 				descriptorDir: this.descriptorDir,
@@ -674,6 +678,7 @@ export class DaemonSupervisor {
 				generation: this.generation,
 				appVersion: VERSION,
 				preserveLegacyWindowsWorkerOwnership: this.hasPersistedWorkerDescriptors(),
+				...(selectedRegistryDir ? { registryDir: supervisorRegistryDir } : {}),
 			});
 			await prepareDaemonSocketPath(this.socketPath, this.socketLease);
 

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2379,6 +2379,9 @@ export class DaemonSupervisor {
 			if (startupGate instanceof Writable) {
 				startupGate.destroy();
 			}
+			if (child.exitCode === null && child.signalCode === null) {
+				child.kill("SIGKILL");
+			}
 			await childClosed;
 			child.unref();
 			try {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1435,6 +1435,7 @@ export class DaemonSupervisor {
 					this.commandJournal.recordResult(journalIdentity.clientId, journalIdentity.commandId, response);
 				}
 				this.write(client, response);
+				this.scheduleSupervisorCloseAfterResponse(command);
 			}
 		} catch (error) {
 			this.log(`Supervisor command ${command.type} failed: ${error instanceof Error ? error.stack : String(error)}`);
@@ -1660,10 +1661,8 @@ export class DaemonSupervisor {
 				return success(command.id, command.type, summary ? this.publicSummary(worker, summary) : undefined);
 			}
 			case "restart":
-				setImmediate(() => void this.shutdown(0, false, true, false, "update"));
 				return success(command.id, command.type);
 			case "shutdown":
-				setImmediate(() => void this.shutdown(0, true, false, command.force === true, "shutdown"));
 				return success(command.id, "shutdown");
 			case "prepare_update_restart": {
 				const manifest = await this.prepareUpdateRestart();
@@ -5261,6 +5260,16 @@ export class DaemonSupervisor {
 
 	private write(client: DaemonSocketClient, message: DaemonOutbound): boolean {
 		return this.writeSerialized(client, serializeJsonLine(message));
+	}
+
+	private scheduleSupervisorCloseAfterResponse(command: DaemonCommand): void {
+		if (command.type === "shutdown") {
+			setImmediate(() => void this.shutdown(0, true, false, command.force === true, "shutdown"));
+			return;
+		}
+		if (command.type === "restart") {
+			setImmediate(() => void this.shutdown(0, false, true, false, "update"));
+		}
 	}
 
 	private broadcastHeartbeatsChanged(): void {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -5428,7 +5428,7 @@ export class DaemonSupervisor {
 			await Promise.all(
 				[...this.workers.values()].map(async (worker) => {
 					try {
-						await this.stopWorker(worker, true, forceWorkers);
+						await this.stopWorker(worker, true, forceWorkers, worker.descriptor.ownerClientId === undefined);
 					} catch (error) {
 						if (!(error instanceof WorkerStopTimeoutError)) {
 							throw error;

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -37,7 +37,15 @@ function cacheAutomaticShellConfig(key: string, config: ShellConfig): ShellConfi
 /**
  * Find bash executable on PATH (cross-platform)
  */
-function findExecutableOnWindowsPath(executable: string): string | null {
+function isWindowsWslBashLauncher(shellPath: string): boolean {
+	const normalized = shellPath.replace(/\//g, "\\").toLowerCase();
+	return normalized.endsWith("\\system32\\bash.exe") || normalized.endsWith("\\syswow64\\bash.exe");
+}
+
+function findExecutableOnWindowsPath(
+	executable: string,
+	isUsable: (path: string) => boolean = () => true,
+): string | null {
 	try {
 		const result = spawnSync("where.exe", [executable], {
 			encoding: "utf-8",
@@ -45,9 +53,10 @@ function findExecutableOnWindowsPath(executable: string): string | null {
 			windowsHide: true,
 		});
 		if (result.status === 0 && result.stdout) {
-			const firstMatch = result.stdout.trim().split(/\r?\n/)[0];
-			if (firstMatch && existsSync(firstMatch)) {
-				return firstMatch;
+			for (const match of result.stdout.trim().split(/\r?\n/)) {
+				if (match && existsSync(match) && isUsable(match)) {
+					return match;
+				}
 			}
 		}
 	} catch {
@@ -58,7 +67,7 @@ function findExecutableOnWindowsPath(executable: string): string | null {
 
 function findBashOnPath(): string | null {
 	if (process.platform === "win32") {
-		return findExecutableOnWindowsPath("bash.exe");
+		return findExecutableOnWindowsPath("bash.exe", (path) => !isWindowsWslBashLauncher(path));
 	}
 
 	// Unix: Use 'which' and trust its output (handles Termux and special filesystems)
@@ -136,7 +145,7 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 			}
 		}
 
-		// 3. Fallback: search bash.exe on PATH (Cygwin, MSYS2, WSL, etc.)
+		// 3. Fallback: search bash.exe on PATH (Git Bash, Cygwin, MSYS2). Skip the WSL launcher.
 		const bashOnPath = findBashOnPath();
 		if (bashOnPath) {
 			return cacheAutomaticShellConfig(cacheKey, { shell: bashOnPath, args: ["-c"] });

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { basename, delimiter } from "node:path";
+import { delimiter } from "node:path";
 import { type ChildProcess, spawnSync } from "child_process";
 import { getBinDir } from "../config.js";
 import { recordOrphanProcessState } from "../core/orphan-process-journal.js";
@@ -90,7 +90,7 @@ function findBashOnPath(): string | null {
 }
 
 export function isPowerShellShell(shellPath: string): boolean {
-	const executable = basename(shellPath).toLowerCase();
+	const executable = shellPath.replace(/\\/g, "/").split("/").pop()?.toLowerCase() ?? "";
 	return (
 		executable === "pwsh" ||
 		executable === "pwsh.exe" ||

--- a/packages/coding-agent/test/acp-cold-cli.test.ts
+++ b/packages/coding-agent/test/acp-cold-cli.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -52,11 +52,16 @@ interface AcpResult {
 
 async function driveAcpTurn(baseUrl: string): Promise<AcpResult> {
 	const tempRoot = mkdtempSync(join(tmpdir(), "pi-acp-cold-"));
+	chmodSync(tempRoot, 0o700);
 	tempDirs.push(tempRoot);
 	const agentDir = join(tempRoot, "agent");
 	const projectDir = join(tempRoot, "project");
+	const registryDir = join(agentDir, "supervisor-owners");
 	mkdirSync(agentDir, { recursive: true });
 	mkdirSync(projectDir, { recursive: true });
+	mkdirSync(registryDir, { recursive: true });
+	chmodSync(agentDir, 0o700);
+	chmodSync(registryDir, 0o700);
 	writeFileSync(
 		join(agentDir, "models.json"),
 		JSON.stringify({
@@ -93,6 +98,8 @@ async function driveAcpTurn(baseUrl: string): Promise<AcpResult> {
 			env: isolatedDaemonProcessEnv({
 				[ENV_AGENT_DIR]: agentDir,
 				HOME: agentDir,
+				PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR: registryDir,
+				PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_SELECTED_REGISTRY_DIR: registryDir,
 				TSX_TSCONFIG_PATH: resolve(__dirname, "../../../tsconfig.json"),
 			}),
 			stdio: ["pipe", "pipe", "pipe"],

--- a/packages/coding-agent/test/acp-cold-cli.test.ts
+++ b/packages/coding-agent/test/acp-cold-cli.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { ENV_AGENT_DIR } from "../src/config.js";
+import { isolatedDaemonProcessEnv } from "./isolated-daemon-env.js";
 
 /**
  * Cold real-CLI ACP coverage.
@@ -89,12 +90,11 @@ async function driveAcpTurn(baseUrl: string): Promise<AcpResult> {
 		],
 		{
 			cwd: projectDir,
-			env: {
-				...process.env,
+			env: isolatedDaemonProcessEnv({
 				[ENV_AGENT_DIR]: agentDir,
 				HOME: agentDir,
 				TSX_TSCONFIG_PATH: resolve(__dirname, "../../../tsconfig.json"),
-			},
+			}),
 			stdio: ["pipe", "pipe", "pipe"],
 		},
 	);

--- a/packages/coding-agent/test/child-process.test.ts
+++ b/packages/coding-agent/test/child-process.test.ts
@@ -101,7 +101,7 @@ describe("process liveness", () => {
 			process.execPath,
 			[
 				"--eval",
-				'const { spawn } = require("node:child_process"); const child = spawn(process.execPath, ["--eval", "setInterval(() => {}, 1000)"], { stdio: "ignore" }); process.stdout.write(String(child.pid));',
+				'const { spawn } = require("node:child_process"); const child = spawn(process.execPath, ["--eval", "setInterval(() => {}, 1000)"], { stdio: "ignore" }); child.unref(); process.stdout.write(String(child.pid));',
 			],
 			{ detached: true, stdio: ["ignore", "pipe", "ignore"] },
 		);

--- a/packages/coding-agent/test/clipboard.test.ts
+++ b/packages/coding-agent/test/clipboard.test.ts
@@ -121,6 +121,7 @@ describe("copyToClipboard", () => {
 			input: "hello",
 			stdio: ["pipe", "ignore", "ignore"],
 			timeout: 5000,
+			windowsHide: true,
 		});
 		expect(osc52Writes()).toHaveLength(0);
 	});

--- a/packages/coding-agent/test/daemon-command.test.ts
+++ b/packages/coding-agent/test/daemon-command.test.ts
@@ -66,11 +66,6 @@ const daemonClientMock = vi.hoisted(() => {
 				protocol: { name: "prime-agent.daemon", version: DAEMON_PROTOCOL_VERSION },
 				schemaId: DAEMON_SCHEMA_ID,
 				appVersion: VERSION,
-				supervisorGeneration: "test-generation",
-				supervisorOwnerToken: "test-owner",
-				supervisorPid: 99999,
-				supervisorProcessStartId: "test-start",
-				supervisorSocketPath: this.socketPath,
 				clientId: "test-client",
 				serverCapabilities: [],
 			};

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -3712,4 +3712,88 @@ describe("daemon worker supervisor monitoring", () => {
 		await expect(supervisor.prepareUpdateRestartFenced()).rejects.toThrow(/resident-1.*recovering.*disconnected/);
 		expect(requestWorker).not.toHaveBeenCalled();
 	});
+
+	it("writes shutdown success before scheduling daemon_closing", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-shutdown-order-"));
+		const commandJournal = new CommandRecoveryJournal(join(root, "commands.jsonl"));
+		const writes: string[] = [];
+		const shutdown = vi.fn(async () => undefined);
+		const client = {
+			id: "socket-client",
+			socket: {
+				destroyed: false,
+				write: vi.fn((chunk: string) => {
+					writes.push(chunk);
+					return true;
+				}),
+			},
+		} as unknown as DaemonSocketClient;
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			ready: Promise.resolve(),
+			workers: new Map(),
+			protocolClientIds: new WeakMap(),
+			commandJournal,
+			mutationDrain: { begin: vi.fn(), end: vi.fn() },
+			assertCurrentOwnership: vi.fn(async () => undefined),
+			cancelOwnedWorkerCleanup: vi.fn(),
+			shutdown,
+		}) as unknown as {
+			handleLine(client: DaemonSocketClient, line: string): Promise<void>;
+		};
+
+		try {
+			await supervisor.handleLine(
+				client,
+				JSON.stringify(createDaemonCommandEnvelope({ type: "shutdown" }, "command-shutdown", "client-1")),
+			);
+			expect(writes).toEqual([`${JSON.stringify(success("command-shutdown", "shutdown"))}\n`]);
+			expect(shutdown).not.toHaveBeenCalled();
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			expect(shutdown).toHaveBeenCalledWith(0, true, false, false, "shutdown");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("writes restart success before scheduling an update close", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-restart-order-"));
+		const commandJournal = new CommandRecoveryJournal(join(root, "commands.jsonl"));
+		const writes: string[] = [];
+		const shutdown = vi.fn(async () => undefined);
+		const client = {
+			id: "socket-client",
+			socket: {
+				destroyed: false,
+				write: vi.fn((chunk: string) => {
+					writes.push(chunk);
+					return true;
+				}),
+			},
+		} as unknown as DaemonSocketClient;
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			ready: Promise.resolve(),
+			workers: new Map(),
+			protocolClientIds: new WeakMap(),
+			commandJournal,
+			mutationDrain: { begin: vi.fn(), end: vi.fn() },
+			assertCurrentOwnership: vi.fn(async () => undefined),
+			cancelOwnedWorkerCleanup: vi.fn(),
+			shutdown,
+		}) as unknown as {
+			handleLine(client: DaemonSocketClient, line: string): Promise<void>;
+		};
+
+		try {
+			await supervisor.handleLine(
+				client,
+				JSON.stringify(createDaemonCommandEnvelope({ type: "restart" }, "command-restart", "client-1")),
+			);
+			expect(writes).toEqual([`${JSON.stringify(success("command-restart", "restart"))}\n`]);
+			expect(shutdown).not.toHaveBeenCalled();
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			expect(shutdown).toHaveBeenCalledWith(0, false, true, false, "update");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -3665,6 +3665,13 @@ describe("daemon worker supervisor monitoring", () => {
 
 	it("limits abort admission to mutation drain", async () => {
 		const root = mkdtempSync(join(tmpdir(), `prime-update-drain-${process.pid}-`));
+		chmodSync(root, 0o700);
+		const registryDir = join(root, "supervisor-owners");
+		mkdirSync(registryDir, { recursive: true, mode: 0o700 });
+		chmodSync(registryDir, 0o700);
+		supervisorRegistryDirs.add(registryDir);
+		process.env[supervisorRegistryDirEnv] = registryDir;
+		process.env[supervisorSelectedRegistryDirEnv] = registryDir;
 		const socketPath =
 			process.platform === "win32"
 				? `\\\\.\\pipe\\prime-agent-update-drain-${process.pid}-${Date.now()}`

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1,6 +1,15 @@
 import { type ChildProcess, type SpawnOptions, spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import type { Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -1106,6 +1115,7 @@ describe("daemon worker supervisor monitoring", () => {
 
 		rmSync(registryDir, { force: true });
 		mkdirSync(registryDir, { recursive: true });
+		chmodSync(registryDir, 0o700);
 		await vi.advanceTimersByTimeAsync(5000);
 		await probeCompleted;
 		expect(daemon.canConnectToSupervisor).toHaveBeenCalledOnce();
@@ -3435,6 +3445,9 @@ describe("daemon worker supervisor monitoring", () => {
 		};
 		const markInterrupted = vi.fn(async () => undefined);
 		const kill = vi.spyOn(process, "kill").mockReturnValue(true);
+		const reapSpy = vi
+			.spyOn(childProcessModule, "terminateUnixProcessGroupByIdentity")
+			.mockResolvedValue("terminated");
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			catalog: { markInterrupted },
 			log: vi.fn(),
@@ -3461,6 +3474,7 @@ describe("daemon worker supervisor monitoring", () => {
 			);
 		} finally {
 			kill.mockRestore();
+			reapSpy.mockRestore();
 			rmSync(root, { recursive: true, force: true });
 		}
 	});

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -115,7 +115,9 @@ vi.mock("../src/core/session-lease.js", async (importOriginal) => {
 });
 
 const supervisorRegistryDirEnv = "PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR";
+const supervisorSelectedRegistryDirEnv = "PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_SELECTED_REGISTRY_DIR";
 const previousSupervisorRegistryDir = process.env[supervisorRegistryDirEnv];
+const previousSupervisorSelectedRegistryDir = process.env[supervisorSelectedRegistryDirEnv];
 const supervisorRegistryDirs = new Set<string>();
 
 interface SupervisorMonitorHarness {
@@ -263,6 +265,7 @@ function createHarness(canConnect: () => Promise<boolean>): SupervisorMonitorHar
 	const registryDir = mkdtempSync(join(tmpdir(), "prime-supervisor-registry-test-"));
 	supervisorRegistryDirs.add(registryDir);
 	process.env[supervisorRegistryDirEnv] = registryDir;
+	process.env[supervisorSelectedRegistryDirEnv] = registryDir;
 	return Object.assign(Object.create(AgentDaemon.prototype), {
 		options: { worker: {} },
 		clients: new Set<{ authenticated: boolean }>(),
@@ -298,6 +301,11 @@ describe("daemon worker supervisor monitoring", () => {
 			delete process.env[supervisorRegistryDirEnv];
 		} else {
 			process.env[supervisorRegistryDirEnv] = previousSupervisorRegistryDir;
+		}
+		if (previousSupervisorSelectedRegistryDir === undefined) {
+			delete process.env[supervisorSelectedRegistryDirEnv];
+		} else {
+			process.env[supervisorSelectedRegistryDirEnv] = previousSupervisorSelectedRegistryDir;
 		}
 	});
 
@@ -534,6 +542,7 @@ describe("daemon worker supervisor monitoring", () => {
 		mkdirSync(registryDir, { recursive: true });
 		supervisorRegistryDirs.add(root);
 		process.env[supervisorRegistryDirEnv] = registryDir;
+		process.env[supervisorSelectedRegistryDirEnv] = registryDir;
 		let assertionCount = 0;
 		const workers = new Map<string, unknown>();
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
@@ -771,7 +780,7 @@ describe("daemon worker supervisor monitoring", () => {
 		mkdirSync(descriptorDir, { recursive: true });
 		supervisorRegistryDirs.add(root);
 		workerLaunchTestState.capture = true;
-		workerLaunchTestState.forceMissingProcessStartId = process.platform !== "win32";
+		workerLaunchTestState.forceMissingProcessStartId = false;
 		workerLaunchTestState.fixtureMode = "successful-gate";
 		workerLaunchTestState.gateMarkerPath = markerPath;
 		const cancellation = recoveryDeniedError("supervisor_recovery_cancelled");

--- a/packages/coding-agent/test/daemon-supervisor-process.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-process.test.ts
@@ -1,15 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import {
-	chmodSync,
-	existsSync,
-	mkdirSync,
-	mkdtempSync,
-	readdirSync,
-	readFileSync,
-	rmSync,
-	writeFileSync,
-} from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -26,7 +17,7 @@ import { DaemonAgentConnection } from "../src/modes/agent-connection/daemon-agen
 import { DaemonClient, getDaemonSocketCloseReason } from "../src/modes/daemon/daemon-client.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 import type { DaemonWorkerDescriptor } from "../src/modes/daemon/daemon-worker-protocol.js";
-import { isolatedDaemonProcessEnv } from "./isolated-daemon-env.js";
+import { isolatedDaemonProcessEnv, removeTempRoot } from "./isolated-daemon-env.js";
 
 const cliPath = resolve(__dirname, "../src/cli.ts");
 const tsxPath = resolve(__dirname, "../../../node_modules/tsx/dist/cli.mjs");
@@ -51,12 +42,14 @@ afterEach(async () => {
 		}
 	}
 	daemonSockets.clear();
-	for (const child of children) {
+	const liveChildren = [...children];
+	children.clear();
+	for (const child of liveChildren) {
 		if (child.exitCode === null && child.signalCode === null) {
 			child.kill("SIGTERM");
 		}
 	}
-	children.clear();
+	await Promise.all(liveChildren.map((child) => waitForExit(child).catch(() => undefined)));
 	for (const pid of workerPids) {
 		try {
 			process.kill(pid, "SIGCONT");
@@ -75,7 +68,7 @@ afterEach(async () => {
 	}
 	workerPids.clear();
 	for (const directory of tempDirs.splice(0)) {
-		rmSync(directory, { recursive: true, force: true });
+		await removeTempRoot(directory);
 	}
 });
 
@@ -213,6 +206,15 @@ async function connectEventually(socketPath: string, child?: ChildProcess): Prom
 		}
 	}
 	throw new Error(`Timed out waiting for supervisor: ${String(lastError)}`);
+}
+
+async function requestShutdown(client: DaemonClient, timeoutMs?: number): Promise<void> {
+	try {
+		const response = await client.request({ type: "shutdown" }, timeoutMs);
+		expect(response.success).toBe(true);
+	} catch (error) {
+		expect(getDaemonSocketCloseReason(error as Error)).toBe("shutdown");
+	}
 }
 
 async function waitForSocketGone(socketPath: string): Promise<void> {
@@ -410,7 +412,7 @@ describe("daemon supervisor resident workers", () => {
 		});
 		expect(countWorkerDescriptors(agentDir)).toBe(1);
 
-		await client.request({ type: "shutdown" });
+		await requestShutdown(client);
 		client.close();
 		await waitForSocketGone(socketPath);
 	}, 60_000);
@@ -514,7 +516,7 @@ describe("daemon supervisor resident workers", () => {
 		);
 		expect((await readSessionInfo(sessionFile))?.state?.status).not.toBe("archived");
 
-		await client.request({ type: "shutdown" });
+		await requestShutdown(client);
 		client.close();
 		await waitForSocketGone(socketPath);
 	}, 60_000);
@@ -562,7 +564,7 @@ describe("daemon supervisor resident workers", () => {
 			"Adopted client-owned worker descriptor was not removed",
 		);
 		const replacementClient = await connectEventually(socketPath);
-		await replacementClient.request({ type: "shutdown" });
+		await requestShutdown(replacementClient);
 		replacementClient.close();
 		await waitForSocketGone(socketPath);
 	}, 60_000);
@@ -611,8 +613,7 @@ describe("daemon supervisor resident workers", () => {
 				deliveryStatus: "queued",
 			},
 		});
-		const shutdown = await client.request({ type: "shutdown" }, 10_000);
-		expect(shutdown.success).toBe(true);
+		await requestShutdown(client, 10_000);
 		client.close();
 		await waitForSocketGone(socketPath);
 	}, 30_000);
@@ -665,7 +666,7 @@ describe("daemon supervisor resident workers", () => {
 		).toEqual([]);
 		expect((await readSessionInfo(sessionFile))?.state).toEqual({ status: "archived" });
 
-		await client.request({ type: "shutdown" });
+		await requestShutdown(client);
 		client.close();
 		await waitForSocketGone(socketPath);
 	});
@@ -715,7 +716,7 @@ describe("daemon supervisor resident workers", () => {
 			),
 		).toEqual([]);
 
-		await client.request({ type: "shutdown" });
+		await requestShutdown(client);
 		client.close();
 		await waitForSocketGone(socketPath);
 	});
@@ -746,7 +747,7 @@ describe("daemon supervisor resident workers", () => {
 		expect(readSupervisorConfig(agentDir)).toMatchObject({
 			defaultSessionConfig: { sessionDir, noTools: true },
 		});
-		await replacementClient.request({ type: "shutdown" });
+		await requestShutdown(replacementClient);
 		replacementClient.close();
 		await waitForSocketGone(socketPath);
 	});
@@ -772,7 +773,7 @@ describe("daemon supervisor resident workers", () => {
 		expect(listed.success).toBe(true);
 		expect(requireSessionList(listed.success ? listed.data : undefined)).toEqual([]);
 
-		await client.request({ type: "shutdown" });
+		await requestShutdown(client);
 		client.close();
 		await waitForSocketGone(socketPath);
 	});
@@ -822,7 +823,7 @@ describe("daemon supervisor resident workers", () => {
 		const observer = await connectEventually(socketPath, supervisor);
 		const observerClosed = new Promise<Error>((resolveClose) => observer.onClose(resolveClose));
 
-		expect((await client.request({ type: "shutdown" })).success).toBe(true);
+		await requestShutdown(client);
 		client.close();
 		expect(getDaemonSocketCloseReason(await observerClosed)).toBe("shutdown");
 		observer.close();
@@ -842,7 +843,7 @@ describe("daemon supervisor resident workers", () => {
 				(session) => session.activeSessionId || session.workerPid,
 			),
 		).toEqual([]);
-		await replacementClient.request({ type: "shutdown" });
+		await requestShutdown(replacementClient);
 		replacementClient.close();
 		await waitForSocketGone(socketPath);
 	}, 30_000);
@@ -906,7 +907,7 @@ describe("daemon supervisor resident workers", () => {
 			20_000,
 		);
 
-		await client.request({ type: "shutdown" });
+		await requestShutdown(client);
 		client.close();
 		await waitForSocketGone(socketPath);
 	});
@@ -983,7 +984,7 @@ describe("daemon supervisor resident workers", () => {
 		});
 		expect(attached.success).toBe(true);
 
-		await client.request({ type: "shutdown" });
+		await requestShutdown(client);
 		client.close();
 		await waitForSocketGone(socketPath);
 		if (resumedSummary.workerPid) {
@@ -1070,7 +1071,7 @@ describe("daemon supervisor resident workers", () => {
 		expect((await readSessionInfo(sessionFile))?.state).toEqual({ status: "archived" });
 		expect(cronStore.list().find((job) => job.id === heartbeat.id)).toMatchObject({ status: "cancelled" });
 
-		await replacementClient.request({ type: "shutdown" });
+		await requestShutdown(replacementClient);
 		replacementClient.close();
 		await waitForSocketGone(socketPath);
 	});
@@ -1133,7 +1134,7 @@ describe("daemon supervisor resident workers", () => {
 		expect(
 			new Set(requireSessionList(adopted.success ? adopted.data : undefined).map((summary) => summary.workerPid)),
 		).toEqual(new Set(pids));
-		await replacementClient.request({ type: "shutdown" });
+		await requestShutdown(replacementClient);
 		replacementClient.close();
 		await waitForSocketGone(socketPath);
 		await Promise.all(
@@ -1270,7 +1271,7 @@ describe("daemon supervisor resident workers", () => {
 		expect(
 			new Set(requireSessionList(adopted.success ? adopted.data : undefined).map((summary) => summary.workerPid)),
 		).toEqual(new Set(pids));
-		await replacementClient.request({ type: "shutdown" });
+		await requestShutdown(replacementClient);
 		replacementClient.close();
 		await waitForSocketGone(socketPath);
 		await Promise.all(
@@ -1456,7 +1457,7 @@ describe("daemon supervisor resident workers", () => {
 		await expect(connection.getState()).resolves.toMatchObject({ sessionId: createdSummary.sessionId });
 
 		await connection.dispose();
-		await client.request({ type: "shutdown" });
+		await requestShutdown(client);
 		client.close();
 		await waitForSocketGone(socketPath);
 		await waitForProcessGone(recovered.workerPid);
@@ -1524,7 +1525,7 @@ describe("daemon supervisor resident workers", () => {
 		expect(store.list().find((candidate) => candidate.id === job.id)).toBeDefined();
 
 		const replacement = await connectEventually(socketPath);
-		await replacement.request({ type: "shutdown" });
+		await requestShutdown(replacement);
 		replacement.close();
 		await waitForSocketGone(socketPath);
 		await waitForProcessGone(summary.workerPid);

--- a/packages/coding-agent/test/daemon-supervisor-process.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-process.test.ts
@@ -17,6 +17,7 @@ import { DaemonAgentConnection } from "../src/modes/agent-connection/daemon-agen
 import { DaemonClient, getDaemonSocketCloseReason } from "../src/modes/daemon/daemon-client.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 import type { DaemonWorkerDescriptor } from "../src/modes/daemon/daemon-worker-protocol.js";
+import { isolatedDaemonProcessEnv } from "./isolated-daemon-env.js";
 
 const cliPath = resolve(__dirname, "../src/cli.ts");
 const tsxPath = resolve(__dirname, "../../../node_modules/tsx/dist/cli.mjs");
@@ -87,12 +88,11 @@ function spawnSupervisor(
 		[tsxPath, cliPath, "--mode", "daemon", "--daemon-socket", socketPath, "--offline", ...extraArgs],
 		{
 			cwd,
-			env: {
-				...process.env,
+			env: isolatedDaemonProcessEnv({
 				[ENV_AGENT_DIR]: agentDir,
 				PI_OFFLINE: "1",
 				TSX_TSCONFIG_PATH: resolve(__dirname, "../../../tsconfig.json"),
-			},
+			}),
 			stdio: ["ignore", "pipe", "pipe"],
 		},
 	);

--- a/packages/coding-agent/test/daemon-supervisor-process.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-process.test.ts
@@ -1,6 +1,15 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -72,6 +81,7 @@ afterEach(async () => {
 
 function tempDir(): string {
 	const directory = mkdtempSync(join(tmpdir(), "prime-daemon-supervisor-test-"));
+	chmodSync(directory, 0o700);
 	tempDirs.push(directory);
 	return directory;
 }
@@ -83,6 +93,10 @@ function spawnSupervisor(
 	extraArgs: readonly string[] = [],
 ): ChildProcess {
 	daemonSockets.add(socketPath);
+	const registryDir = join(agentDir, "supervisor-owners");
+	mkdirSync(registryDir, { recursive: true });
+	chmodSync(agentDir, 0o700);
+	chmodSync(registryDir, 0o700);
 	const child = spawn(
 		process.execPath,
 		[tsxPath, cliPath, "--mode", "daemon", "--daemon-socket", socketPath, "--offline", ...extraArgs],
@@ -90,6 +104,8 @@ function spawnSupervisor(
 			cwd,
 			env: isolatedDaemonProcessEnv({
 				[ENV_AGENT_DIR]: agentDir,
+				PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR: registryDir,
+				PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_SELECTED_REGISTRY_DIR: registryDir,
 				PI_OFFLINE: "1",
 				TSX_TSCONFIG_PATH: resolve(__dirname, "../../../tsconfig.json"),
 			}),

--- a/packages/coding-agent/test/daemon-supervisor-process.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-process.test.ts
@@ -730,8 +730,12 @@ describe("daemon supervisor resident workers", () => {
 
 		const supervisor = spawnSupervisor(agentDir, socketPath, projectDir, ["--session-dir", sessionDir, "--no-tools"]);
 		const client = await connectEventually(socketPath, supervisor);
-		const restarted = await client.request({ type: "restart" });
-		expect(restarted.success).toBe(true);
+		try {
+			const restarted = await client.request({ type: "restart" });
+			expect(restarted.success).toBe(true);
+		} catch (error) {
+			expect(getDaemonSocketCloseReason(error as Error)).toBe("update");
+		}
 		client.close();
 		await waitForExit(supervisor);
 		children.delete(supervisor);

--- a/packages/coding-agent/test/interactive-mode-effort-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-effort-command.test.ts
@@ -472,7 +472,7 @@ describe("InteractiveMode /effort", () => {
 
 			expect(context.agentConnection.setServiceTier).not.toHaveBeenCalled();
 			expect(context.showStatus).toHaveBeenCalledWith(
-				"Fast mode requires GPT-5.4, GPT-5.5, or GPT-5.6 with ChatGPT authentication",
+				"Fast mode requires GPT-5.4, GPT-5.5, or GPT-5.6 with ChatGPT authentication, or Grok 4.5/4.6 with an xAI Grok subscription",
 			);
 		});
 

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -2231,6 +2231,7 @@ describe("InteractiveMode model selection persistence", () => {
 		expect(order).toEqual(["connection", "settings"]);
 		expect(fakeThis.patchConnectionState).toHaveBeenCalledWith({
 			model,
+			thinkingLevel: "medium",
 			serviceTier: "default",
 			availableThinkingLevels: ["off"],
 		});
@@ -2303,6 +2304,7 @@ describe("InteractiveMode model selection persistence", () => {
 		expect(fakeThis.uiServices.settingsManager.setDefaultModelAndProvider).toHaveBeenCalledWith("openai", "gpt-5.5");
 		expect(fakeThis.patchConnectionState).toHaveBeenCalledWith({
 			model,
+			thinkingLevel: "medium",
 			serviceTier: "default",
 			availableThinkingLevels: ["off"],
 		});

--- a/packages/coding-agent/test/ipython-provisioner.test.ts
+++ b/packages/coding-agent/test/ipython-provisioner.test.ts
@@ -126,11 +126,9 @@ describe("IpythonKernelProvisioner", () => {
 		provisioner.prewarm();
 		expect(provisioner.manager).toBeUndefined();
 
-		// Once the prewarm startup settles, ensure() must launch a second attempt.
-		await vi.waitFor(async () => {
-			await expect(provisioner.ensure()).rejects.toThrow();
-			expect(countRuns()).toBeGreaterThanOrEqual(2);
-		});
+		await expect(provisioner.ensure()).rejects.toThrow();
+		await expect(provisioner.ensure()).rejects.toThrow();
+		expect(countRuns()).toBeGreaterThanOrEqual(2);
 	});
 
 	it("replays the current startup stage to listeners attaching mid-flight", async () => {

--- a/packages/coding-agent/test/isolated-daemon-env.ts
+++ b/packages/coding-agent/test/isolated-daemon-env.ts
@@ -2,7 +2,7 @@
  * Strip parent-daemon supervisor/worker env so real-process tests do not
  * attach to the agent that launched the test runner.
  */
-import { chmodSync, mkdirSync, mkdtempSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -43,4 +43,20 @@ export function isolatedDaemonProcessEnv(overrides: NodeJS.ProcessEnv = {}): Nod
 		}
 	}
 	return env;
+}
+
+export async function removeTempRoot(root: string): Promise<void> {
+	for (let attempt = 0; attempt < 20; attempt++) {
+		try {
+			rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+			return;
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException).code;
+			if (code !== "ENOTEMPTY" && code !== "EBUSY") {
+				throw error;
+			}
+			await new Promise((resolveDelay) => setTimeout(resolveDelay, 50));
+		}
+	}
+	rmSync(root, { recursive: true, force: true, maxRetries: 20, retryDelay: 100 });
 }

--- a/packages/coding-agent/test/isolated-daemon-env.ts
+++ b/packages/coding-agent/test/isolated-daemon-env.ts
@@ -2,6 +2,16 @@
  * Strip parent-daemon supervisor/worker env so real-process tests do not
  * attach to the agent that launched the test runner.
  */
+import { chmodSync, mkdirSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export function createSecureTempDir(prefix: string): string {
+	const directory = mkdtempSync(join(tmpdir(), prefix));
+	chmodSync(directory, 0o700);
+	return directory;
+}
+
 const PARENT_DAEMON_ENV_KEYS = [
 	"PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR",
 	"PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_SELECTED_REGISTRY_DIR",
@@ -15,6 +25,15 @@ const PARENT_DAEMON_ENV_KEYS = [
 	"PRIME_AGENT_INTERNAL_SESSION_LEASES",
 	"PRIME_AGENT_INTERNAL_SESSION_LEASE_OWNER_ID",
 ] as const;
+
+export function isolatedDaemonRegistryDir(agentDir: string): string {
+	const registryDir = join(agentDir, "supervisor-owners");
+	mkdirSync(agentDir, { recursive: true });
+	mkdirSync(registryDir, { recursive: true });
+	chmodSync(agentDir, 0o700);
+	chmodSync(registryDir, 0o700);
+	return registryDir;
+}
 
 export function isolatedDaemonProcessEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
 	const env: NodeJS.ProcessEnv = { ...process.env, ...overrides };

--- a/packages/coding-agent/test/isolated-daemon-env.ts
+++ b/packages/coding-agent/test/isolated-daemon-env.ts
@@ -1,0 +1,27 @@
+/**
+ * Strip parent-daemon supervisor/worker env so real-process tests do not
+ * attach to the agent that launched the test runner.
+ */
+const PARENT_DAEMON_ENV_KEYS = [
+	"PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR",
+	"PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_SELECTED_REGISTRY_DIR",
+	"PRIME_AGENT_INTERNAL_DAEMON_WORKER",
+	"PRIME_AGENT_INTERNAL_DAEMON_WORKER_TOKEN",
+	"PRIME_AGENT_INTERNAL_DAEMON_WORKER_ACTIVE_SESSION_ID",
+	"PRIME_AGENT_INTERNAL_DAEMON_WORKER_RECOVERY_JOURNAL",
+	"PRIME_AGENT_INTERNAL_DAEMON_WORKER_STARTUP_GATE_FD",
+	"PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_SOCKET",
+	"PRIME_AGENT_INTERNAL_ORPHAN_PROCESS_JOURNAL",
+	"PRIME_AGENT_INTERNAL_SESSION_LEASES",
+	"PRIME_AGENT_INTERNAL_SESSION_LEASE_OWNER_ID",
+] as const;
+
+export function isolatedDaemonProcessEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = { ...process.env, ...overrides };
+	for (const key of PARENT_DAEMON_ENV_KEYS) {
+		if (!(key in overrides) || overrides[key] === undefined) {
+			delete env[key];
+		}
+	}
+	return env;
+}

--- a/packages/coding-agent/test/login-dialog.test.ts
+++ b/packages/coding-agent/test/login-dialog.test.ts
@@ -108,7 +108,12 @@ describe("LoginDialogComponent", () => {
 
 			dialog.showAuth(url);
 
-			expect(mocks.execFile).toHaveBeenCalledWith(command, [...prefixArgs, url], expect.any(Function));
+			expect(mocks.execFile).toHaveBeenCalledWith(
+				command,
+				[...prefixArgs, url],
+				{ windowsHide: true },
+				expect.any(Function),
+			);
 		} finally {
 			platformSpy.mockRestore();
 		}

--- a/packages/coding-agent/test/shell.test.ts
+++ b/packages/coding-agent/test/shell.test.ts
@@ -31,9 +31,12 @@ const originalEnv = {
 	"ProgramFiles(x86)": process.env["ProgramFiles(x86)"],
 	SystemRoot: process.env.SystemRoot,
 };
+const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
 
 afterEach(() => {
-	vi.spyOn(process, "platform", "get").mockRestore();
+	if (originalPlatform) {
+		Object.defineProperty(process, "platform", originalPlatform);
+	}
 	mocks.spawnSync.mockReset();
 	process.env.PATH = originalEnv.PATH;
 	process.env.Path = originalEnv.Path;
@@ -58,7 +61,10 @@ function mockWindowsShellLookup(options: {
 	existing: readonly string[];
 	where: Record<string, string[]>;
 }): void {
-	vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+	Object.defineProperty(process, "platform", {
+		configurable: true,
+		value: "win32",
+	});
 	process.env.ProgramFiles = "C:\\Missing Program Files";
 	process.env["ProgramFiles(x86)"] = "C:\\Missing Program Files (x86)";
 	process.env.SystemRoot = "C:\\Windows";
@@ -78,28 +84,30 @@ function mockWindowsShellLookup(options: {
 describe("Windows automatic shell resolution", () => {
 	it("skips the WSL System32 bash launcher and selects PowerShell", () => {
 		const pwsh = "C:\\Program Files\\PowerShell\\7\\pwsh.exe";
+		const wslBash = "C:\\Windows\\System32\\bash.exe";
 		mockWindowsShellLookup({
 			pathSuffix: "wsl-only",
-			existing: [pwsh],
+			existing: [pwsh, wslBash],
 			where: {
-				"bash.exe": ["C:\\Windows\\System32\\bash.exe"],
+				"bash.exe": [wslBash],
 				"pwsh.exe": [pwsh],
 			},
 		});
 
 		const config = getShellConfig();
-		expect(isPowerShellShell(config.shell)).toBe(true);
 		expect(config.shell).toBe(pwsh);
+		expect(isPowerShellShell(config.shell)).toBe(true);
 		expect(config.args).toEqual(["-NoLogo", "-NoProfile", "-NonInteractive", "-Command"]);
 	});
 
 	it("skips SysWOW64 bash and still prefers a real bash later on PATH", () => {
 		const msysBash = "C:\\tools\\msys64\\usr\\bin\\bash.exe";
+		const wow64Bash = "C:\\Windows\\SysWOW64\\bash.exe";
 		mockWindowsShellLookup({
 			pathSuffix: "msys",
-			existing: [msysBash],
+			existing: [msysBash, wow64Bash],
 			where: {
-				"bash.exe": ["C:\\Windows\\SysWOW64\\bash.exe", msysBash],
+				"bash.exe": [wow64Bash, msysBash],
 			},
 		});
 

--- a/packages/coding-agent/test/shell.test.ts
+++ b/packages/coding-agent/test/shell.test.ts
@@ -81,6 +81,16 @@ function mockWindowsShellLookup(options: {
 	});
 }
 
+describe("isPowerShellShell", () => {
+	it("recognizes PowerShell executables from Windows and POSIX paths", () => {
+		expect(isPowerShellShell(String.raw`C:\Program Files\PowerShell\7\pwsh.exe`)).toBe(true);
+		expect(isPowerShellShell(String.raw`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`)).toBe(true);
+		expect(isPowerShellShell("/usr/bin/pwsh")).toBe(true);
+		expect(isPowerShellShell("/bin/bash")).toBe(false);
+		expect(isPowerShellShell(String.raw`C:\Windows\System32\bash.exe`)).toBe(false);
+	});
+});
+
 describe("Windows automatic shell resolution", () => {
 	it("skips the WSL System32 bash launcher and selects PowerShell", () => {
 		const pwsh = "C:\\Program Files\\PowerShell\\7\\pwsh.exe";

--- a/packages/coding-agent/test/shell.test.ts
+++ b/packages/coding-agent/test/shell.test.ts
@@ -1,0 +1,109 @@
+import type { SpawnSyncReturns } from "child_process";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getShellConfig, isPowerShellShell } from "../src/utils/shell.js";
+
+const mocks = vi.hoisted(() => ({
+	existsSync: vi.fn<(path: string) => boolean>(),
+	spawnSync: vi.fn<(command: string, args?: readonly string[]) => SpawnSyncReturns<string>>(),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	mocks.existsSync.mockImplementation((path) => actual.existsSync(path));
+	return {
+		...actual,
+		existsSync: (path: Parameters<typeof actual.existsSync>[0]) => mocks.existsSync(String(path)),
+	};
+});
+
+vi.mock("child_process", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("child_process")>();
+	return {
+		...actual,
+		spawnSync: mocks.spawnSync,
+	};
+});
+
+const originalEnv = {
+	PATH: process.env.PATH,
+	Path: process.env.Path,
+	ProgramFiles: process.env.ProgramFiles,
+	"ProgramFiles(x86)": process.env["ProgramFiles(x86)"],
+	SystemRoot: process.env.SystemRoot,
+};
+
+afterEach(() => {
+	vi.spyOn(process, "platform", "get").mockRestore();
+	mocks.spawnSync.mockReset();
+	process.env.PATH = originalEnv.PATH;
+	process.env.Path = originalEnv.Path;
+	process.env.ProgramFiles = originalEnv.ProgramFiles;
+	process.env["ProgramFiles(x86)"] = originalEnv["ProgramFiles(x86)"];
+	process.env.SystemRoot = originalEnv.SystemRoot;
+});
+
+function spawnResult(stdout: string, status = 0): SpawnSyncReturns<string> {
+	return {
+		pid: 1,
+		output: [null, stdout, ""],
+		stdout,
+		stderr: "",
+		status,
+		signal: null,
+	};
+}
+
+function mockWindowsShellLookup(options: {
+	pathSuffix: string;
+	existing: readonly string[];
+	where: Record<string, string[]>;
+}): void {
+	vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+	process.env.ProgramFiles = "C:\\Missing Program Files";
+	process.env["ProgramFiles(x86)"] = "C:\\Missing Program Files (x86)";
+	process.env.SystemRoot = "C:\\Windows";
+	process.env.PATH = `C:\\Program Files\\PowerShell\\7;C:\\Windows\\System32;${options.pathSuffix}`;
+	const existing = new Set(options.existing);
+	mocks.existsSync.mockImplementation((path) => existing.has(path));
+	mocks.spawnSync.mockImplementation((command, args) => {
+		const executable = args?.[0] ?? "";
+		if (command === "where.exe") {
+			const matches = options.where[executable] ?? [];
+			return spawnResult(matches.join("\r\n"), matches.length > 0 ? 0 : 1);
+		}
+		return spawnResult("", 1);
+	});
+}
+
+describe("Windows automatic shell resolution", () => {
+	it("skips the WSL System32 bash launcher and selects PowerShell", () => {
+		const pwsh = "C:\\Program Files\\PowerShell\\7\\pwsh.exe";
+		mockWindowsShellLookup({
+			pathSuffix: "wsl-only",
+			existing: [pwsh],
+			where: {
+				"bash.exe": ["C:\\Windows\\System32\\bash.exe"],
+				"pwsh.exe": [pwsh],
+			},
+		});
+
+		const config = getShellConfig();
+		expect(isPowerShellShell(config.shell)).toBe(true);
+		expect(config.shell).toBe(pwsh);
+		expect(config.args).toEqual(["-NoLogo", "-NoProfile", "-NonInteractive", "-Command"]);
+	});
+
+	it("skips SysWOW64 bash and still prefers a real bash later on PATH", () => {
+		const msysBash = "C:\\tools\\msys64\\usr\\bin\\bash.exe";
+		mockWindowsShellLookup({
+			pathSuffix: "msys",
+			existing: [msysBash],
+			where: {
+				"bash.exe": ["C:\\Windows\\SysWOW64\\bash.exe", msysBash],
+			},
+		});
+
+		const config = getShellConfig();
+		expect(config).toEqual({ shell: msysBash, args: ["-c"] });
+	});
+});

--- a/packages/coding-agent/test/stdout-cleanliness.test.ts
+++ b/packages/coding-agent/test/stdout-cleanliness.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { ENV_AGENT_DIR } from "../src/config.js";
+import { ENV_AGENT_DIR, VERSION } from "../src/config.js";
 
 const cliPath = resolve(__dirname, "../src/cli.ts");
 const tsxPath = resolve(__dirname, "../../../node_modules/tsx/dist/cli.mjs");
@@ -104,5 +104,16 @@ describe("stdout cleanliness in non-interactive modes", () => {
 		expect(result.stderr).toContain("Usage:");
 		expect(result.stderr).not.toContain("Examples:");
 		expect(result.stderr).not.toContain("Built-in Tool Names:");
+	});
+
+	it("prints --version to stdout without a help banner", async () => {
+		const result = await runCli(["--version"]);
+
+		expect(result.code).toBe(0);
+		expect(result.stdout.trim()).toBe(VERSION);
+		expect(result.stdout).not.toContain("Usage:");
+		expect(result.stderr).not.toContain("Usage:");
+		expect(result.stderr).not.toContain("changed 1 package in 471ms");
+		expect(result.stderr).not.toContain("found 0 vulnerabilities");
 	});
 });

--- a/packages/coding-agent/test/suite/agent-session-bash-persistence.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-bash-persistence.test.ts
@@ -160,6 +160,7 @@ describe("AgentSession bash and persistence characterization", () => {
 
 		const entries = harness.sessionManager.getEntries();
 		expect(entries.map((entry) => entry.type)).toEqual([
+			"service_tier_change",
 			"custom_message",
 			"message",
 			"message",

--- a/packages/coding-agent/test/suite/daemon-serialized-refine-process.test.ts
+++ b/packages/coding-agent/test/suite/daemon-serialized-refine-process.test.ts
@@ -26,14 +26,14 @@
  */
 
 import { type ChildProcess, spawn } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { ENV_AGENT_DIR } from "../../src/config.js";
 import { DaemonClient } from "../../src/modes/daemon/daemon-client.js";
 import { DAEMON_WORKER_ROLE_ENV } from "../../src/modes/daemon/daemon-worker-protocol.js";
-import { isolatedDaemonProcessEnv, isolatedDaemonRegistryDir } from "../isolated-daemon-env.js";
+import { isolatedDaemonProcessEnv, isolatedDaemonRegistryDir, removeTempRoot } from "../isolated-daemon-env.js";
 
 const cliPath = resolve(__dirname, "../../src/cli.ts");
 const tsxPath = resolve(__dirname, "../../../../node_modules/tsx/dist/cli.mjs");
@@ -45,12 +45,29 @@ const daemonSockets = new Set<string>();
 const tempRoots = new Set<string>();
 
 afterEach(async () => {
-	for (const child of children) {
+	const liveChildren = [...children];
+	children.clear();
+	for (const child of liveChildren) {
 		if (child.exitCode === null && child.signalCode === null) {
 			child.kill("SIGKILL");
 		}
 	}
-	children.clear();
+	await Promise.all(
+		liveChildren.map(
+			(child) =>
+				new Promise<void>((resolveExit) => {
+					if (child.exitCode !== null || child.signalCode !== null) {
+						resolveExit();
+						return;
+					}
+					const timeout = setTimeout(() => resolveExit(), 10_000);
+					child.once("exit", () => {
+						clearTimeout(timeout);
+						resolveExit();
+					});
+				}),
+		),
+	);
 	for (const socketPath of daemonSockets) {
 		const client = new DaemonClient(socketPath);
 		try {
@@ -67,7 +84,7 @@ afterEach(async () => {
 	}
 	daemonSockets.clear();
 	for (const root of tempRoots) {
-		rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+		await removeTempRoot(root);
 	}
 	tempRoots.clear();
 });
@@ -140,6 +157,7 @@ function writeAutoRefineSettings(agentDir: string): void {
 describe("Real-process serializedRefine — JSON mode", () => {
 	it("daemon supervisor scrubs inherited worker env, checkpoint applies refine_complete before agent_end", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-agent-process-json-refine-"));
+		chmodSync(root, 0o700);
 		tempRoots.add(root);
 		const agentDir = join(root, "agent");
 		mkdirSync(agentDir, { recursive: true });

--- a/packages/coding-agent/test/suite/daemon-serialized-refine-process.test.ts
+++ b/packages/coding-agent/test/suite/daemon-serialized-refine-process.test.ts
@@ -33,7 +33,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { ENV_AGENT_DIR } from "../../src/config.js";
 import { DaemonClient } from "../../src/modes/daemon/daemon-client.js";
 import { DAEMON_WORKER_ROLE_ENV } from "../../src/modes/daemon/daemon-worker-protocol.js";
-import { isolatedDaemonProcessEnv } from "../isolated-daemon-env.js";
+import { isolatedDaemonProcessEnv, isolatedDaemonRegistryDir } from "../isolated-daemon-env.js";
 
 const cliPath = resolve(__dirname, "../../src/cli.ts");
 const tsxPath = resolve(__dirname, "../../../../node_modules/tsx/dist/cli.mjs");
@@ -83,6 +83,8 @@ async function runCli(
 			PI_SKIP_VERSION_CHECK: "1",
 			PRIME_AGENT_INTERNAL_LEGACY_OWNED_WORKER_FRONTEND: "0",
 			PRIME_AGENT_KERNEL_FORKSERVER: "0",
+			PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR: isolatedDaemonRegistryDir(options.agentDir),
+			PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_SELECTED_REGISTRY_DIR: isolatedDaemonRegistryDir(options.agentDir),
 			RLM_DEPTH: "0",
 			...options.environment,
 		}),

--- a/packages/coding-agent/test/suite/daemon-serialized-refine-process.test.ts
+++ b/packages/coding-agent/test/suite/daemon-serialized-refine-process.test.ts
@@ -31,16 +31,9 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { ENV_AGENT_DIR } from "../../src/config.js";
-import { ORPHAN_PROCESS_JOURNAL_ENV } from "../../src/core/orphan-process-journal.js";
-import { SESSION_LEASE_OWNER_ID_ENV, SESSION_LEASES_ENABLED_ENV } from "../../src/core/session-lease.js";
 import { DaemonClient } from "../../src/modes/daemon/daemon-client.js";
-import {
-	DAEMON_WORKER_ACTIVE_SESSION_ID_ENV,
-	DAEMON_WORKER_RECOVERY_JOURNAL_ENV,
-	DAEMON_WORKER_ROLE_ENV,
-	DAEMON_WORKER_SUPERVISOR_SOCKET_ENV,
-	DAEMON_WORKER_TOKEN_ENV,
-} from "../../src/modes/daemon/daemon-worker-protocol.js";
+import { DAEMON_WORKER_ROLE_ENV } from "../../src/modes/daemon/daemon-worker-protocol.js";
+import { isolatedDaemonProcessEnv } from "../isolated-daemon-env.js";
 
 const cliPath = resolve(__dirname, "../../src/cli.ts");
 const tsxPath = resolve(__dirname, "../../../../node_modules/tsx/dist/cli.mjs");
@@ -84,28 +77,15 @@ async function runCli(
 	options: { agentDir: string; stdin?: string; environment?: NodeJS.ProcessEnv },
 ): Promise<{ code: number | null; signal: NodeJS.Signals | null; stdout: string; stderr: string }> {
 	const child = spawn(process.execPath, [tsxPath, cliPath, ...args], {
-		env: {
-			...process.env,
+		env: isolatedDaemonProcessEnv({
 			TSX_TSCONFIG_PATH: repoTsconfigPath,
 			[ENV_AGENT_DIR]: options.agentDir,
 			PI_SKIP_VERSION_CHECK: "1",
 			PRIME_AGENT_INTERNAL_LEGACY_OWNED_WORKER_FRONTEND: "0",
 			PRIME_AGENT_KERNEL_FORKSERVER: "0",
 			RLM_DEPTH: "0",
-			// The test deliberately RE-INJECTS the worker role env var
-			// (via options.environment, applied last) to prove the
-			// production daemon-launch.ts env scrub removes it before
-			// spawning the daemon supervisor.
-			[DAEMON_WORKER_ROLE_ENV]: undefined,
-			[DAEMON_WORKER_TOKEN_ENV]: undefined,
-			[DAEMON_WORKER_ACTIVE_SESSION_ID_ENV]: undefined,
-			[DAEMON_WORKER_RECOVERY_JOURNAL_ENV]: undefined,
-			[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV]: undefined,
-			[ORPHAN_PROCESS_JOURNAL_ENV]: undefined,
-			[SESSION_LEASES_ENABLED_ENV]: undefined,
-			[SESSION_LEASE_OWNER_ID_ENV]: undefined,
 			...options.environment,
-		},
+		}),
 		stdio: ["pipe", "pipe", "pipe"],
 	});
 	children.add(child);

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -244,10 +244,21 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 		cleanup() {
 			session.dispose();
 			fauxProvider.unregister();
-			if (existsSync(tempDir)) {
-				// Spawned fixture processes may still be flushing their final registry
-				// writes; retry briefly instead of failing the suite on ENOTEMPTY.
-				rmSync(tempDir, { recursive: true, force: true, maxRetries: 40, retryDelay: 50 });
+			if (!existsSync(tempDir)) {
+				return;
+			}
+			// Spawned fixture processes may still hold the temp tree after exit
+			// (Windows EBUSY, Linux ENOTEMPTY). Retry instead of failing the suite.
+			for (let attempt = 0; attempt < 50; attempt++) {
+				try {
+					rmSync(tempDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+					return;
+				} catch (error) {
+					const code = (error as NodeJS.ErrnoException).code;
+					if (code !== "EBUSY" && code !== "ENOTEMPTY" && code !== "ENOENT") {
+						throw error;
+					}
+				}
 			}
 		},
 	};

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -2,7 +2,7 @@
  * Local test harness for the new coding-agent test suite.
  */
 
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentMessage, AgentTool } from "@earendil-works/pi-agent-core";
@@ -103,6 +103,7 @@ export interface Harness {
 function createTempDir(): string {
 	const tempDir = join(tmpdir(), `pi-suite-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	mkdirSync(tempDir, { recursive: true });
+	chmodSync(tempDir, 0o700);
 	return tempDir;
 }
 

--- a/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
@@ -79,6 +79,7 @@ const cliPath = resolve(__dirname, "../../../src/cli.ts");
 const tsxPath = resolve(__dirname, "../../../../../node_modules/tsx/dist/cli.mjs");
 const tsconfigPath = resolve(__dirname, "../../../../../tsconfig.json");
 const supervisorRegistryDirEnv = "PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR";
+const supervisorSelectedRegistryDirEnv = "PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_SELECTED_REGISTRY_DIR";
 const handles = new Set<FixtureHandle>();
 const harnesses: Harness[] = [];
 const cleanupProcesses = new Map<string, CleanupProcessIdentity>();
@@ -148,9 +149,11 @@ function spawnFixture(
 	};
 	if (options.useDefaultRegistry) {
 		delete environment[supervisorRegistryDirEnv];
+		delete environment[supervisorSelectedRegistryDirEnv];
 		environment.ENG_4600_PROBE_BEFORE_RELEASE = "1";
 	} else {
 		environment[supervisorRegistryDirEnv] = paths.registryDir;
+		environment[supervisorSelectedRegistryDirEnv] = paths.registryDir;
 		environment.ENG_4600_REGISTRY_DIR = paths.registryDir;
 	}
 	const child = spawn(process.execPath, [tsxPath, fixturePath], {
@@ -189,8 +192,10 @@ function spawnRealSupervisor(
 	};
 	if (useDefaultRegistry) {
 		delete environment[supervisorRegistryDirEnv];
+		delete environment[supervisorSelectedRegistryDirEnv];
 	} else {
 		environment[supervisorRegistryDirEnv] = paths.registryDir;
+		environment[supervisorSelectedRegistryDirEnv] = paths.registryDir;
 	}
 	const child = spawn(
 		process.execPath,

--- a/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
@@ -23,9 +23,12 @@ import type { SessionSummary } from "../../../src/modes/daemon/daemon-session-li
 import {
 	acquireDaemonSupervisorOwnership,
 	adoptLegacyDaemonSupervisorOwnershipFromHello,
+	DAEMON_SUPERVISOR_REGISTRY_DIR_ENV,
+	DAEMON_SUPERVISOR_SELECTED_REGISTRY_DIR_ENV,
 	listDaemonSupervisorAgentDirs,
 	listDaemonSupervisorProcesses,
 	persistDaemonStartupFenceFromOwner,
+	resolveDaemonSupervisorRegistryDir,
 	waitForDaemonStartupFence,
 } from "../../../src/modes/daemon/daemon-supervisor-ownership.js";
 import { terminateWindowsProcessTreeByIdentity } from "../../../src/utils/child-process.js";
@@ -627,6 +630,69 @@ describe("ENG-4600 daemon supervisor ownership", () => {
 			await waitForMessage(owner, (message) => message.type === "probe_ack" || message.type === "failed"),
 		).toMatchObject({ type: "probe_ack" });
 		await releaseOwnershipHolder(owner);
+	});
+
+	it("resolves the selected supervisor registry ahead of the ambient default", () => {
+		const selected = join("selected-registry");
+		const inherited = join("inherited-registry");
+		expect(
+			resolveDaemonSupervisorRegistryDir({
+				[DAEMON_SUPERVISOR_SELECTED_REGISTRY_DIR_ENV]: selected,
+				[DAEMON_SUPERVISOR_REGISTRY_DIR_ENV]: inherited,
+			}),
+		).toBe(selected);
+		expect(
+			resolveDaemonSupervisorRegistryDir({
+				[DAEMON_SUPERVISOR_REGISTRY_DIR_ENV]: inherited,
+			}),
+		).toBe(inherited);
+	});
+
+	it("waits for startup fences in the selected registry without validating an insecure ambient default", async () => {
+		if (process.platform === "win32") {
+			return;
+		}
+		const paths = await createPaths();
+		const insecureAncestor = join(paths.agentDir, "insecure-ambient");
+		const ambientRegistry = join(insecureAncestor, "supervisor-owners");
+		mkdirSync(ambientRegistry, { recursive: true, mode: 0o777 });
+		chmodSync(insecureAncestor, 0o777);
+		await expect(waitForDaemonStartupFence(paths.socketPath, 50, ambientRegistry)).rejects.toThrow(
+			/Insecure daemon supervisor registry/,
+		);
+		await expect(waitForDaemonStartupFence(paths.socketPath, 50, paths.registryDir)).resolves.toBeUndefined();
+	});
+
+	it("starts a supervisor from a selected registry when the ambient temp default is insecure", async () => {
+		const paths = await createPaths();
+		const insecureTemp = join(paths.agentDir, "insecure-temp");
+		mkdirSync(insecureTemp, { recursive: true, mode: 0o755 });
+		chmodSync(insecureTemp, 0o755);
+		const stateHome = join(paths.agentDir, "xdg-state");
+		mkdirSync(stateHome, { recursive: true, mode: 0o700 });
+		chmodSync(stateHome, 0o700);
+		cleanupRegistryDirs.add(paths.registryDir);
+		cleanupSupervisorSockets.add(paths.socketPath);
+		const supervisor = spawnRealSupervisor(
+			paths,
+			{
+				LOCALAPPDATA: join(paths.agentDir, "local-app-data-selected"),
+				TEMP: insecureTemp,
+				TMP: insecureTemp,
+				TMPDIR: insecureTemp,
+				XDG_STATE_HOME: stateHome,
+			},
+			false,
+		);
+		let client: DaemonClient | undefined;
+		try {
+			client = await connectEventually(paths.socketPath);
+			expect(listOwnerRecords(paths.registryDir)).toHaveLength(1);
+			await client.request({ type: "shutdown", force: true }, 5000);
+			await waitForExit(supervisor);
+		} finally {
+			client?.close();
+		}
 	});
 
 	it("keeps a live Windows supervisor commandable after its OS temp root is deleted", async () => {

--- a/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
@@ -313,10 +313,16 @@ async function assertConnectable(socketPath: string): Promise<void> {
 	});
 }
 
-async function connectEventually(socketPath: string): Promise<DaemonClient> {
+async function connectEventually(socketPath: string, supervisor?: FixtureHandle): Promise<DaemonClient> {
 	const deadline = Date.now() + 30_000;
 	let lastError: unknown;
 	while (Date.now() < deadline) {
+		if (supervisor && (supervisor.child.exitCode !== null || supervisor.child.signalCode !== null)) {
+			throw new Error(
+				`Replacement supervisor exited before accepting connections ` +
+					`(exit=${supervisor.child.exitCode}/${supervisor.child.signalCode})\n${supervisor.diagnostics.stderr}`,
+			);
+		}
 		const client = new DaemonClient(socketPath);
 		try {
 			await client.connect(500);
@@ -328,7 +334,10 @@ async function connectEventually(socketPath: string): Promise<DaemonClient> {
 			await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
 		}
 	}
-	throw new Error(`Timed out connecting to replacement supervisor: ${String(lastError)}`);
+	throw new Error(
+		`Timed out connecting to replacement supervisor: ${String(lastError)}` +
+			(supervisor ? `\nSupervisor stderr:\n${supervisor.diagnostics.stderr}` : ""),
+	);
 }
 
 function waitForConnectionStatus(
@@ -686,7 +695,7 @@ describe("ENG-4600 daemon supervisor ownership", () => {
 		);
 		let client: DaemonClient | undefined;
 		try {
-			client = await connectEventually(paths.socketPath);
+			client = await connectEventually(paths.socketPath, supervisor);
 			expect(listOwnerRecords(paths.registryDir)).toHaveLength(1);
 			await client.request({ type: "shutdown", force: true }, 5000);
 			await waitForExit(supervisor);
@@ -718,7 +727,7 @@ describe("ENG-4600 daemon supervisor ownership", () => {
 		);
 		let client: DaemonClient | undefined;
 		try {
-			client = await connectEventually(paths.socketPath);
+			client = await connectEventually(paths.socketPath, supervisor);
 			expect(listOwnerRecords(durableRegistryDir)).toHaveLength(1);
 			rmSync(osTempRoot, { recursive: true, force: true });
 			await new Promise((resolveDelay) => setTimeout(resolveDelay, 500));
@@ -781,7 +790,7 @@ describe("ENG-4600 daemon supervisor ownership", () => {
 		let client: DaemonClient | undefined;
 		let connection: DaemonAgentConnection | undefined;
 		try {
-			client = await connectEventually(paths.socketPath);
+			client = await connectEventually(paths.socketPath, predecessor);
 			let created: Awaited<ReturnType<DaemonClient["request"]>>;
 			try {
 				created = await client.request(
@@ -1362,7 +1371,7 @@ describe("ENG-4600 daemon supervisor ownership", () => {
 		delete scope.agentDir;
 		writeFileSync(ownerScopePath(paths.registryDir, owner.generation), JSON.stringify(scope));
 
-		const client = await connectEventually(paths.socketPath);
+		const client = await connectEventually(paths.socketPath, supervisor);
 		try {
 			const hello = await client.waitForHello(2000);
 			const { supervisorProcessStartId: _helloProcessStartId, ...legacyHello } = hello;

--- a/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
@@ -693,7 +693,7 @@ describe("ENG-4600 daemon supervisor ownership", () => {
 		} finally {
 			client?.close();
 		}
-	});
+	}, 90_000);
 
 	it("keeps a live Windows supervisor commandable after its OS temp root is deleted", async () => {
 		if (process.platform !== "win32") {

--- a/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
@@ -285,10 +285,14 @@ async function createPaths(): Promise<{
 }> {
 	const harness = await createHarness();
 	harnesses.push(harness);
+	const registryDir = join(harness.tempDir, "registry");
+	mkdirSync(registryDir, { recursive: true, mode: 0o700 });
+	chmodSync(harness.tempDir, 0o700);
+	chmodSync(registryDir, 0o700);
 	return {
 		agentDir: harness.tempDir,
 		descriptorDir: join(harness.tempDir, "workers"),
-		registryDir: join(harness.tempDir, "registry"),
+		registryDir,
 		socketPath:
 			process.platform === "win32"
 				? `\\\\.\\pipe\\prime-agent-eng-4600-${process.pid}-${Date.now()}`
@@ -1181,6 +1185,7 @@ describe("ENG-4600 daemon supervisor ownership", () => {
 
 		const insecureAncestor = join(paths.agentDir, "insecure-ancestor");
 		mkdirSync(insecureAncestor, { mode: 0o777 });
+		chmodSync(insecureAncestor, 0o777);
 		await expect(listDaemonSupervisorProcesses(join(insecureAncestor, "registry"))).rejects.toThrow(
 			/Insecure daemon supervisor registry/,
 		);

--- a/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
@@ -17,7 +17,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { APP_NAME, ENV_AGENT_DIR, getCronJobsPath } from "../../../src/config.js";
 import { getProcessStartId } from "../../../src/core/session-lease.js";
 import { DaemonAgentConnection } from "../../../src/modes/agent-connection/daemon-agent-connection.js";
-import { DaemonClient } from "../../../src/modes/daemon/daemon-client.js";
+import { DaemonClient, DaemonSocketClosedError } from "../../../src/modes/daemon/daemon-client.js";
 import { canonicalizeDaemonFilesystemPath } from "../../../src/modes/daemon/daemon-paths.js";
 import type { SessionSummary } from "../../../src/modes/daemon/daemon-session-list.js";
 import {
@@ -29,6 +29,7 @@ import {
 	waitForDaemonStartupFence,
 } from "../../../src/modes/daemon/daemon-supervisor-ownership.js";
 import { terminateWindowsProcessTreeByIdentity } from "../../../src/utils/child-process.js";
+import { isolatedDaemonProcessEnv } from "../../isolated-daemon-env.js";
 import { createHarness, type Harness } from "../harness.js";
 
 type FixtureMessage =
@@ -135,8 +136,7 @@ function spawnFixture(
 	paths: { agentDir: string; descriptorDir: string; registryDir: string; socketPath: string },
 	options: { extraEnv?: NodeJS.ProcessEnv; generation?: string; useDefaultRegistry?: boolean } = {},
 ): FixtureHandle {
-	const environment: NodeJS.ProcessEnv = {
-		...process.env,
+	const environment: NodeJS.ProcessEnv = isolatedDaemonProcessEnv({
 		...options.extraEnv,
 		[ENV_AGENT_DIR]: paths.agentDir,
 		ENG_4600_AGENT_DIR: paths.agentDir,
@@ -146,7 +146,7 @@ function spawnFixture(
 		ENG_4600_SOCKET_PATH: paths.socketPath,
 		PI_OFFLINE: "1",
 		TSX_TSCONFIG_PATH: tsconfigPath,
-	};
+	});
 	if (options.useDefaultRegistry) {
 		delete environment[supervisorRegistryDirEnv];
 		delete environment[supervisorSelectedRegistryDirEnv];
@@ -183,13 +183,12 @@ function spawnRealSupervisor(
 	extraEnv: NodeJS.ProcessEnv,
 	useDefaultRegistry = false,
 ): FixtureHandle {
-	const environment: NodeJS.ProcessEnv = {
-		...process.env,
+	const environment: NodeJS.ProcessEnv = isolatedDaemonProcessEnv({
 		...extraEnv,
 		[ENV_AGENT_DIR]: paths.agentDir,
 		PI_OFFLINE: "1",
 		TSX_TSCONFIG_PATH: tsconfigPath,
-	};
+	});
 	if (useDefaultRegistry) {
 		delete environment[supervisorRegistryDirEnv];
 		delete environment[supervisorSelectedRegistryDirEnv];
@@ -586,6 +585,10 @@ async function stopSupervisor(handle: FixtureHandle, socketPath: string): Promis
 		await client.connect(1000);
 		await client.waitForHello(2000);
 		await client.request({ type: "shutdown" }, 5000);
+	} catch (error) {
+		if (!(error instanceof DaemonSocketClosedError) || error.daemonClosingReason !== "shutdown") {
+			throw error;
+		}
 	} finally {
 		client.close();
 	}

--- a/packages/coding-agent/test/suite/regressions/4603-worker-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4603-worker-recovery.test.ts
@@ -41,6 +41,7 @@ import {
 	type PrivateFrame,
 	PrivateFrameDecoder,
 } from "../../../src/modes/session-worker/private-framing.js";
+import { isolatedDaemonProcessEnv } from "../../isolated-daemon-env.js";
 import { createHarness, type Harness } from "../harness.js";
 
 interface OwnerRecord {
@@ -156,9 +157,9 @@ function spawnSupervisor(paths: TestPaths): ProcessHandle {
 	return trackProcess(
 		spawn(paths.executablePath, [tsxPath, fixturePath], {
 			cwd: paths.agentDir,
-			env: {
-				...process.env,
+			env: isolatedDaemonProcessEnv({
 				[supervisorRegistryDirEnv]: paths.registryDir,
+				PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_SELECTED_REGISTRY_DIR: paths.registryDir,
 				[ENV_AGENT_DIR]: paths.agentDir,
 				ENG_4600_AGENT_DIR: paths.agentDir,
 				ENG_4600_DESCRIPTOR_DIR: paths.descriptorDir,
@@ -168,7 +169,7 @@ function spawnSupervisor(paths: TestPaths): ProcessHandle {
 				PI_OFFLINE: "1",
 				TMPDIR: paths.socketTmpDir,
 				TSX_TSCONFIG_PATH: tsconfigPath,
-			},
+			}),
 			stdio: ["ignore", "pipe", "pipe", "ipc"],
 		}),
 		"supervisor",
@@ -187,10 +188,10 @@ function spawnStandaloneWorker(
 			[tsxPath, cliPath, "--mode", "daemon", "--daemon-socket", workerSocketPath, "--offline"],
 			{
 				cwd: paths.agentDir,
-				env: {
-					...process.env,
+				env: isolatedDaemonProcessEnv({
 					...extraEnv,
 					[supervisorRegistryDirEnv]: paths.registryDir,
+					PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_SELECTED_REGISTRY_DIR: paths.registryDir,
 					[ENV_AGENT_DIR]: paths.agentDir,
 					[DAEMON_WORKER_ROLE_ENV]: "1",
 					[DAEMON_WORKER_TOKEN_ENV]: token,
@@ -198,7 +199,7 @@ function spawnStandaloneWorker(
 					[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV]: paths.socketPath,
 					PI_OFFLINE: "1",
 					TSX_TSCONFIG_PATH: tsconfigPath,
-				},
+				}),
 				stdio: ["ignore", "pipe", "pipe"],
 			},
 		),
@@ -686,15 +687,15 @@ async function runCli(
 	const handle = trackProcess(
 		spawn(process.execPath, [tsxPath, cliPath, ...args], {
 			cwd: paths.agentDir,
-			env: {
-				...process.env,
+			env: isolatedDaemonProcessEnv({
 				...extraEnv,
 				[supervisorRegistryDirEnv]: paths.registryDir,
+				PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_SELECTED_REGISTRY_DIR: paths.registryDir,
 				[ENV_AGENT_DIR]: paths.agentDir,
 				PI_OFFLINE: "1",
 				TMPDIR: paths.socketTmpDir,
 				TSX_TSCONFIG_PATH: tsconfigPath,
-			},
+			}),
 			stdio: ["ignore", "pipe", "pipe"],
 		}),
 		"client",

--- a/packages/coding-agent/test/suite/regressions/4606-update-restart-coordinator.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4606-update-restart-coordinator.test.ts
@@ -12,6 +12,7 @@ import { DaemonAgentConnection } from "../../../src/modes/agent-connection/daemo
 import { DaemonClient } from "../../../src/modes/daemon/daemon-client.js";
 import type { DaemonResponse } from "../../../src/modes/daemon/daemon-protocol.js";
 import type { SessionSummary } from "../../../src/modes/daemon/daemon-session-list.js";
+import { isolatedDaemonProcessEnv } from "../../isolated-daemon-env.js";
 import { createHarness, type Harness } from "../harness.js";
 
 interface SupervisorHandle {
@@ -52,9 +53,9 @@ function spawnSupervisor(paths: {
 		[tsxPath, cliPath, "--mode", "daemon", "--daemon-socket", paths.socketPath, "--offline"],
 		{
 			cwd: paths.agentDir,
-			env: {
-				...process.env,
+			env: isolatedDaemonProcessEnv({
 				[supervisorRegistryDirEnv]: paths.registryDir,
+				PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_SELECTED_REGISTRY_DIR: paths.registryDir,
 				[ENV_AGENT_DIR]: paths.agentDir,
 				ENG_4606_AGENT_DIR: paths.agentDir,
 				ENG_4606_CLI_PATH: cliPath,
@@ -64,7 +65,7 @@ function spawnSupervisor(paths: {
 				ENG_4606_TSX_PATH: tsxPath,
 				PI_OFFLINE: "1",
 				TSX_TSCONFIG_PATH: tsconfigPath,
-			},
+			}),
 			stdio: ["ignore", "pipe", "pipe"],
 		},
 	);

--- a/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
@@ -1,5 +1,5 @@
 import { type ChildProcess, spawn } from "node:child_process";
-import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -12,7 +12,12 @@ import { DaemonSupervisor } from "../../../src/modes/daemon/daemon-supervisor.js
 import { waitForHeadlessCompletion } from "../../../src/modes/headless-completion.js";
 import { RpcClient } from "../../../src/modes/rpc/rpc-client.js";
 import { createRpcExtensionUiBridge } from "../../../src/modes/rpc/rpc-extension-ui-context.js";
-import { createSecureTempDir, isolatedDaemonProcessEnv, isolatedDaemonRegistryDir } from "../../isolated-daemon-env.js";
+import {
+	createSecureTempDir,
+	isolatedDaemonProcessEnv,
+	isolatedDaemonRegistryDir,
+	removeTempRoot,
+} from "../../isolated-daemon-env.js";
 import { createHarness, getAssistantTexts, getUserTexts, type Harness } from "../harness.js";
 
 const fixturePath = resolve(__dirname, "../../fixtures/rpc-connection-mode-fixture.ts");
@@ -25,22 +30,6 @@ const children = new Set<ChildProcess>();
 const harnesses: Harness[] = [];
 const daemonSockets = new Set<string>();
 const tempRoots = new Set<string>();
-
-async function removeTempRoot(root: string): Promise<void> {
-	for (let attempt = 0; attempt < 20; attempt++) {
-		try {
-			rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
-			return;
-		} catch (error) {
-			const code = (error as NodeJS.ErrnoException).code;
-			if (code !== "ENOTEMPTY" && code !== "EBUSY") {
-				throw error;
-			}
-			await new Promise((resolveDelay) => setTimeout(resolveDelay, 50));
-		}
-	}
-	rmSync(root, { recursive: true, force: true, maxRetries: 20, retryDelay: 100 });
-}
 
 afterEach(async () => {
 	for (const child of children) {

--- a/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
@@ -1,6 +1,5 @@
 import { type ChildProcess, spawn } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -13,7 +12,7 @@ import { DaemonSupervisor } from "../../../src/modes/daemon/daemon-supervisor.js
 import { waitForHeadlessCompletion } from "../../../src/modes/headless-completion.js";
 import { RpcClient } from "../../../src/modes/rpc/rpc-client.js";
 import { createRpcExtensionUiBridge } from "../../../src/modes/rpc/rpc-extension-ui-context.js";
-import { isolatedDaemonProcessEnv } from "../../isolated-daemon-env.js";
+import { createSecureTempDir, isolatedDaemonProcessEnv, isolatedDaemonRegistryDir } from "../../isolated-daemon-env.js";
 import { createHarness, getAssistantTexts, getUserTexts, type Harness } from "../harness.js";
 
 const fixturePath = resolve(__dirname, "../../fixtures/rpc-connection-mode-fixture.ts");
@@ -91,6 +90,8 @@ async function runCli(
 			[ENV_AGENT_DIR]: options.agentDir,
 			PI_SKIP_VERSION_CHECK: "1",
 			PRIME_AGENT_INTERNAL_LEGACY_OWNED_WORKER_FRONTEND: "0",
+			PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR: isolatedDaemonRegistryDir(options.agentDir),
+			PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_SELECTED_REGISTRY_DIR: isolatedDaemonRegistryDir(options.agentDir),
 			RLM_DEPTH: undefined,
 			RLM_MAX_DEPTH: undefined,
 			...options.environment,
@@ -261,7 +262,7 @@ describe("ENG-4685 daemon-backed client modes", () => {
 	});
 
 	it("launches real daemon workers for every migrated client surface", async () => {
-		const root = mkdtempSync(join(tmpdir(), "prime-agent-4685-clients-"));
+		const root = createSecureTempDir("prime-agent-4685-clients-");
 		tempRoots.add(root);
 		const agentDir = join(root, "agent dir");
 		const socketPath = join(root, "daemon.sock");
@@ -299,7 +300,7 @@ describe("ENG-4685 daemon-backed client modes", () => {
 	}, 90_000);
 
 	it("keeps the rollback frontend fully off the daemon path", async () => {
-		const root = mkdtempSync(join(tmpdir(), "prime-agent-4685-rollback-"));
+		const root = createSecureTempDir("prime-agent-4685-rollback-");
 		tempRoots.add(root);
 		const agentDir = join(root, "agent");
 		const socketPath = join(root, "must-not-exist.sock");
@@ -329,7 +330,7 @@ describe("ENG-4685 daemon-backed client modes", () => {
 	}, 30_000);
 
 	it("loads headless runtime services only in the worker", async () => {
-		const root = mkdtempSync(join(tmpdir(), "prime-agent-4685-services-"));
+		const root = createSecureTempDir("prime-agent-4685-services-");
 		tempRoots.add(root);
 		const agentDir = join(root, "agent");
 		const socketPath = join(root, "daemon.sock");
@@ -393,7 +394,7 @@ describe("ENG-4685 daemon-backed client modes", () => {
 	});
 
 	it("drains accepted daemon RPC prompt work before EOF", async () => {
-		const root = mkdtempSync(join(tmpdir(), "prime-agent-4685-rpc-eof-"));
+		const root = createSecureTempDir("prime-agent-4685-rpc-eof-");
 		tempRoots.add(root);
 		const socketPath = join(root, "daemon.sock");
 		daemonSockets.add(socketPath);

--- a/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
@@ -26,6 +26,22 @@ const harnesses: Harness[] = [];
 const daemonSockets = new Set<string>();
 const tempRoots = new Set<string>();
 
+async function removeTempRoot(root: string): Promise<void> {
+	for (let attempt = 0; attempt < 20; attempt++) {
+		try {
+			rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+			return;
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException).code;
+			if (code !== "ENOTEMPTY" && code !== "EBUSY") {
+				throw error;
+			}
+			await new Promise((resolveDelay) => setTimeout(resolveDelay, 50));
+		}
+	}
+	rmSync(root, { recursive: true, force: true, maxRetries: 20, retryDelay: 100 });
+}
+
 afterEach(async () => {
 	for (const child of children) {
 		if (child.exitCode === null && child.signalCode === null) {
@@ -52,7 +68,7 @@ afterEach(async () => {
 	}
 	daemonSockets.clear();
 	for (const root of tempRoots) {
-		rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+		await removeTempRoot(root);
 	}
 	tempRoots.clear();
 });

--- a/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
@@ -13,6 +13,7 @@ import { DaemonSupervisor } from "../../../src/modes/daemon/daemon-supervisor.js
 import { waitForHeadlessCompletion } from "../../../src/modes/headless-completion.js";
 import { RpcClient } from "../../../src/modes/rpc/rpc-client.js";
 import { createRpcExtensionUiBridge } from "../../../src/modes/rpc/rpc-extension-ui-context.js";
+import { isolatedDaemonProcessEnv } from "../../isolated-daemon-env.js";
 import { createHarness, getAssistantTexts, getUserTexts, type Harness } from "../harness.js";
 
 const fixturePath = resolve(__dirname, "../../fixtures/rpc-connection-mode-fixture.ts");
@@ -85,21 +86,15 @@ async function runCli(
 	options: { agentDir: string; stdin?: string; environment?: NodeJS.ProcessEnv },
 ): Promise<CliResult> {
 	const child = spawn(process.execPath, [tsxPath, cliPath, ...args], {
-		env: {
-			...process.env,
+		env: isolatedDaemonProcessEnv({
 			TSX_TSCONFIG_PATH: repoTsconfigPath,
 			[ENV_AGENT_DIR]: options.agentDir,
 			PI_SKIP_VERSION_CHECK: "1",
 			PRIME_AGENT_INTERNAL_LEGACY_OWNED_WORKER_FRONTEND: "0",
-			PRIME_AGENT_INTERNAL_DAEMON_WORKER: undefined,
-			PRIME_AGENT_INTERNAL_DAEMON_WORKER_TOKEN: undefined,
-			PRIME_AGENT_INTERNAL_DAEMON_WORKER_ACTIVE_SESSION_ID: undefined,
-			PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_SOCKET: undefined,
-			PRIME_AGENT_INTERNAL_DAEMON_WORKER_RECOVERY_JOURNAL: undefined,
 			RLM_DEPTH: undefined,
 			RLM_MAX_DEPTH: undefined,
 			...options.environment,
-		},
+		}),
 		stdio: ["pipe", "pipe", "pipe"],
 	});
 	children.add(child);


### PR DESCRIPTION
## Summary
First slice of the CI-red work on main. These failures were already present before #10; they are stale tests or flaky waits, not product regressions from the fast-mode default.

- Copilot interleaved-thinking beta requires `thinkingEnabled`
- clipboard/login `windowsHide: true`
- model-select patches now include `thinkingLevel`
- `/fast` copy includes Grok
- harness records an initial `service_tier_change`
- daemon start hello must pass identity reconcile (fake pid caused retry storms)
- empty daemon-socket catches documented
- IPython prewarm retry no longer races `waitFor`

Still failing on CI and not in this PR: real-process daemon supervisor / ownership / smoke / ACP cold CLI. Those need a separate pass.