### PR TITLE
feat(coding-agent): allow explicit reasoning effort on rlm subagent spawn

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added `effort` to `rlm.run` so a parent can set a child's reasoning level at spawn, and included each model's supported levels on `rlm.find_models` matches.
 - Fixed daemon supervisor registry validation rejecting macOS temp paths outside the process temp boundary because `/var` is a symlink, which prevented startup with a selected registry under an insecure ambient temp.
 - Fixed daemon startup fencing inspecting the ambient default registry instead of the selected supervisor registry.
 - Fixed the IPython kernel startup timing out on slow or loaded runners before it could answer the readiness probe.

--- a/packages/coding-agent/docs/rlm-runtime.md
+++ b/packages/coding-agent/docs/rlm-runtime.md
@@ -150,21 +150,22 @@ await rlm.run("subtask")
 
 Supported `rlm.run` options are:
 
-- `name`: a unique readable child session name; and
-- `model`: an exact `provider/model` selector from `rlm.find_models()`.
+- `name`: a unique readable child session name;
+- `model`: an exact `provider/model` selector from `rlm.find_models()`; and
+- `effort`: an explicit reasoning level (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`) that the selected child model must support.
 
-Unknown options fail instead of being ignored. Model search is bounded to active, non-expired credentials. If an exact selection is unavailable or fails auth preflight, spawn fails instead of silently falling back to another model. A child otherwise inherits the parent model.
+Unknown options fail instead of being ignored. Model search is bounded to active, non-expired credentials. Each `rlm.find_models()` match includes `reasoning_levels` for that model, so a parent can see whether `xhigh` (or another level) is actually available. If an exact selection is unavailable or fails auth preflight, or if a requested `effort` is unknown or unsupported by the selected model, spawn fails instead of silently falling back. A child otherwise inherits the parent model and the parent reasoning level clamped to the child model.
 
 ## Child Execution
 
 `AgentSession.runRlmChild()` performs the following sequence:
 
 1. Check `RLM_DEPTH < RLM_MAX_DEPTH`.
-2. Resolve the requested model or inherit the parent model.
+2. Resolve the requested model or inherit the parent model, then apply an explicit `effort` or inherit the parent reasoning level clamped to the child model.
 3. Create a `sub-xxxxxxxx` child directory under the parent artifact directory.
 4. Admit the task into the parent registry and return its `RLMSpawnHandle`.
 5. In detached work, create a child `SessionManager`, `Agent`, and `AgentSession`.
-6. Reuse provider hooks, resource loader, model registry, tools, transport, retry settings, and thinking configuration.
+6. Reuse provider hooks, resource loader, model registry, tools, transport, retry settings, and the resolved thinking level.
 7. Run the child prompt, retain its session, and update lifecycle state independently of the admission call.
 8. Attribute child usage to the parent assistant turn and persist the attribution.
 

--- a/packages/coding-agent/docs/rlm.md
+++ b/packages/coding-agent/docs/rlm.md
@@ -59,7 +59,7 @@ handle = await rlm("Review the authentication flow for security issues", name="a
 print(handle.rlm_child_id, handle.name, handle.session_dir, handle.model)
 ```
 
-The call returns immediately after task admission with a child handle; it never waits for or returns the child's answer. The TypeScript host creates a normal child `AgentSession` with an independent context and session directory. The child inherits the parent model, provider configuration, skills, tools, retry policy, and resource loader unless the call requests another configured model.
+The call returns immediately after task admission with a child handle; it never waits for or returns the child's answer. The TypeScript host creates a normal child `AgentSession` with an independent context and session directory. The child inherits the parent model, reasoning effort, provider configuration, skills, tools, retry policy, and resource loader unless the call requests another configured model or an explicit `effort`. Use `rlm.find_models()` to inspect each match's `reasoning_levels` before choosing `model` and `effort`.
 
 Spawn independent children in separate calls and end the turn instead of awaiting completion:
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -222,6 +222,7 @@ import {
 	createRlmListSubagentsHostHandler,
 	createRlmRunHostHandler,
 	findRlmModelMatches,
+	normalizeRequestedRlmSubagentEffort,
 	normalizeRequestedRlmSubagentModel,
 	normalizeRequestedRlmSubagentSessionName,
 	type RlmDeleteSubagentResult,
@@ -230,6 +231,7 @@ import {
 	type RlmSpawnHandle,
 	type RlmSubagentRegistryEntry,
 	type RlmSubagentRuntime,
+	resolveRlmSubagentThinkingLevel,
 	type SubagentRuntimeHost,
 } from "./rlm-runtime.js";
 import {
@@ -9027,6 +9029,7 @@ export class AgentSession {
 		spawnCode?: string;
 		sessionDir: string;
 		model: Model<any>;
+		thinkingLevel: ThinkingLevel;
 	}): CreateRlmSubagentRuntimeOptions {
 		return {
 			parentSession: this,
@@ -9036,7 +9039,7 @@ export class AgentSession {
 			spawnCode: options.spawnCode,
 			sessionDir: options.sessionDir,
 			model: options.model,
-			thinkingLevel: clampThinkingLevel(options.model, this.thinkingLevel) as ThinkingLevel,
+			thinkingLevel: options.thinkingLevel,
 			serviceTier:
 				this.serviceTier === "priority" && !supportsFastMode(options.model) ? "default" : this.serviceTier,
 			scopedModels: [...this._scopedModels],
@@ -9700,13 +9703,14 @@ export class AgentSession {
 		kwargs: Record<string, unknown> = {},
 		spawnCode?: string,
 	): Promise<RlmSpawnHandle> {
-		const { name: rawName, model: rawModel, ...unsupported } = kwargs;
+		const { name: rawName, model: rawModel, effort: rawEffort, ...unsupported } = kwargs;
 		const unsupportedKwargs = Object.keys(unsupported);
 		if (unsupportedKwargs.length > 0) {
 			throw new Error(`Unsupported rlm.run kwargs: ${unsupportedKwargs.sort().join(", ")}`);
 		}
 		const requestedSessionName = normalizeRequestedRlmSubagentSessionName(rawName);
 		const requestedModel = normalizeRequestedRlmSubagentModel(rawModel);
+		const requestedEffort = normalizeRequestedRlmSubagentEffort(rawEffort);
 		if (requestedSessionName) assertDirectAgentMessageTarget(requestedSessionName);
 		if (this._rlmDepth >= this._rlmMaxDepth) {
 			throw new Error(
@@ -9726,6 +9730,7 @@ export class AgentSession {
 		} finally {
 			if (requestedSessionName) this._pendingRlmSubagentSessionNames.delete(requestedSessionName);
 		}
+		const thinkingLevel = resolveRlmSubagentThinkingLevel(modelSelection.model, this.thinkingLevel, requestedEffort);
 		if (this._disposed || this._disposing) throw new Error("Cannot spawn a subagent after its parent was disposed");
 
 		const childSessionDir = this._createChildRlmSessionDir();
@@ -9796,6 +9801,7 @@ export class AgentSession {
 				spawnCode,
 				sessionDir: childSessionDir,
 				model: modelSelection.model,
+				thinkingLevel,
 			}),
 			onSessionPublished: publishChildSession,
 		};

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -128,7 +128,8 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 			"",
 			"A callable `rlm` is already in your global namespace. `await rlm('sub-task')` spawns a child and returns immediately after task admission with `rlm_child_id`, `name`, `session_dir`, and `model`; it never waits for or returns the child's answer.",
 			"Choose a stable child name with `await rlm('sub-task', name='api-reviewer')`; names must be unique among siblings. If omitted, the host generates a readable unique name.",
-			"A child inherits your model. If a different model is explicitly requested, use `await rlm.find_models(...)` and an exact returned selector. An unavailable requested model fails spawn; decide whether to retry or omit `model`.",
+			"A child inherits your model and reasoning effort. If a different model is requested, use `await rlm.find_models(...)` and an exact returned selector; each match includes `reasoning_levels`.",
+			"Choose spawn-time effort with `effort='xhigh'` (or `off`/`minimal`/`low`/`medium`/`high`/`max`) when the selected model lists that level. An unavailable model or unsupported effort fails spawn; decide whether to retry or omit `model`/`effort`. Unknown `rlm.run` options fail.",
 		);
 		if (hasAgentMessage) {
 			parts.push(

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -1,5 +1,11 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
-import type { Api, Model, ServiceTier } from "@earendil-works/pi-ai";
+import {
+	type Api,
+	clampThinkingLevel,
+	getSupportedThinkingLevels,
+	type Model,
+	type ServiceTier,
+} from "@earendil-works/pi-ai";
 import type { AgentSession } from "./agent-session.js";
 import type { ToolDefinition } from "./extensions/index.js";
 import type { HostRequestHandler } from "./kernel/index.js";
@@ -38,11 +44,14 @@ export interface RlmDeleteSubagentResult {
 	outcome?: "deleted" | "skipped_running";
 }
 
+export const RLM_REASONING_EFFORT_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+
 export interface RlmModelMatch {
 	provider: string;
 	id: string;
 	name: string;
 	selector: string;
+	reasoning_levels: ThinkingLevel[];
 }
 
 export interface RlmFindModelsResult {
@@ -89,6 +98,48 @@ export function normalizeRequestedRlmSubagentModel(value: unknown): string | und
 		throw new Error("rlm.run model must not be empty");
 	}
 	return model;
+}
+
+function isRlmReasoningEffort(value: string): value is ThinkingLevel {
+	return (RLM_REASONING_EFFORT_LEVELS as readonly string[]).includes(value);
+}
+
+/** Validate and normalize an orchestrator-supplied child reasoning effort. */
+export function normalizeRequestedRlmSubagentEffort(value: unknown): ThinkingLevel | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	if (typeof value !== "string") {
+		throw new Error("rlm.run effort must be a string");
+	}
+	const effort = value.trim().toLowerCase();
+	if (!effort) {
+		throw new Error("rlm.run effort must not be empty");
+	}
+	if (!isRlmReasoningEffort(effort)) {
+		throw new Error(`rlm.run effort must be one of ${RLM_REASONING_EFFORT_LEVELS.join(", ")}`);
+	}
+	return effort;
+}
+
+/** Apply an explicit spawn effort, or inherit the parent level clamped to the child model. */
+export function resolveRlmSubagentThinkingLevel(
+	model: Model<Api>,
+	parentLevel: ThinkingLevel,
+	requestedEffort: ThinkingLevel | undefined,
+): ThinkingLevel {
+	if (requestedEffort === undefined) {
+		return clampThinkingLevel(model, parentLevel) as ThinkingLevel;
+	}
+	const supported = getSupportedThinkingLevels(model) as ThinkingLevel[];
+	if (!supported.includes(requestedEffort)) {
+		const selector = `${model.provider}/${model.id}`;
+		const supportedLabel = supported.length > 0 ? supported.join(", ") : "none";
+		throw new Error(
+			`Requested subagent effort "${requestedEffort}" is not supported by ${selector} (supported: ${supportedLabel})`,
+		);
+	}
+	return requestedEffort;
 }
 
 /** Create a readable, collision-resistant default name usable as an agent-message selector. */
@@ -145,6 +196,7 @@ export function findRlmModelMatches(query: string, models: Model<Api>[], limit: 
 			id: model.id,
 			name: model.name || model.id,
 			selector,
+			reasoning_levels: getSupportedThinkingLevels(model) as ThinkingLevel[],
 		}));
 }
 

--- a/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
@@ -34,6 +34,7 @@ describe("ENG-4649 subagent model selection", () => {
 						id: "model-319",
 						name: "model-319",
 						selector: `${provider}/model-319`,
+						reasoning_levels: ["off"],
 					},
 				],
 			});

--- a/packages/coding-agent/test/suite/subagent-reasoning-effort.test.ts
+++ b/packages/coding-agent/test/suite/subagent-reasoning-effort.test.ts
@@ -1,0 +1,228 @@
+import { fauxAssistantMessage, getModel, getSupportedThinkingLevels } from "@earendil-works/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import type { HostRequestHandlers } from "../../src/core/kernel/index.js";
+import { findRlmModelMatches } from "../../src/core/rlm-runtime.js";
+import { createHarness } from "./harness.js";
+
+const provider = "faux-subagent-effort";
+
+const opusLikeCapabilities = {
+	control: "effort" as const,
+	levels: {
+		off: "off",
+		low: "low",
+		medium: "medium",
+		high: "high",
+		xhigh: "xhigh",
+		max: "max",
+	},
+};
+
+const grok45LikeCapabilities = {
+	control: "effort" as const,
+	levels: {
+		off: null,
+		minimal: null,
+		low: "low",
+		medium: "medium",
+		high: "high",
+		xhigh: null,
+		max: null,
+	},
+};
+
+describe("subagent reasoning effort", () => {
+	it("applies an explicit supported effort including xhigh instead of the parent level", async () => {
+		const harness = await createHarness({
+			provider,
+			models: [
+				{
+					id: "parent-model",
+					reasoning: true,
+					reasoningCapabilities: grok45LikeCapabilities,
+				},
+				{
+					id: "opus-like",
+					name: "Opus Like",
+					reasoning: true,
+					reasoningCapabilities: opusLikeCapabilities,
+				},
+			],
+		});
+		try {
+			harness.session.setThinkingLevel("medium");
+			harness.setResponses([fauxAssistantMessage("child at xhigh")]);
+
+			const result = await harness.session.runRlmChild("review at xhigh", {
+				model: `${provider}/opus-like`,
+				effort: "xhigh",
+			});
+			await vi.waitFor(() => {
+				expect(harness.session.getRlmChildSession(result.rlm_child_id)).toBeDefined();
+			});
+
+			const child = harness.session.getRlmChildSession(result.rlm_child_id);
+			expect(harness.session.thinkingLevel).toBe("medium");
+			expect(child?.thinkingLevel).toBe("xhigh");
+			expect(child?.model?.id).toBe("opus-like");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("inherits the parent effort clamped to the child model when effort is omitted", async () => {
+		const harness = await createHarness({
+			provider,
+			models: [
+				{
+					id: "parent-model",
+					reasoning: true,
+					reasoningCapabilities: opusLikeCapabilities,
+				},
+				{
+					id: "grok-45-like",
+					name: "Grok 4.5 Like",
+					reasoning: true,
+					reasoningCapabilities: grok45LikeCapabilities,
+				},
+			],
+		});
+		try {
+			harness.session.setThinkingLevel("xhigh");
+			harness.setResponses([fauxAssistantMessage("inherited child")]);
+
+			const result = await harness.session.runRlmChild("inherit effort", {
+				model: `${provider}/grok-45-like`,
+			});
+			await vi.waitFor(() => {
+				expect(harness.session.getRlmChildSession(result.rlm_child_id)).toBeDefined();
+			});
+
+			expect(harness.session.thinkingLevel).toBe("xhigh");
+			expect(harness.session.getRlmChildSession(result.rlm_child_id)?.thinkingLevel).toBe("high");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("rejects an unsupported requested effort at admission without starting a child", async () => {
+		const harness = await createHarness({
+			provider,
+			models: [
+				{
+					id: "parent-model",
+					reasoning: true,
+					reasoningCapabilities: grok45LikeCapabilities,
+				},
+			],
+		});
+		try {
+			harness.session.setThinkingLevel("medium");
+			harness.setResponses([fauxAssistantMessage("should not run")]);
+
+			await expect(
+				harness.session.runRlmChild("unsupported xhigh", {
+					model: `${provider}/parent-model`,
+					effort: "xhigh",
+				}),
+			).rejects.toThrow(
+				`Requested subagent effort "xhigh" is not supported by ${provider}/parent-model (supported: low, medium, high)`,
+			);
+			expect((await harness.session.listRlmSubagents()).subagents).toEqual([]);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("rejects an unknown effort string and a non-effort unknown kwarg without starting a child", async () => {
+		const harness = await createHarness({
+			provider,
+			models: [{ id: "parent-model", reasoning: true, reasoningCapabilities: opusLikeCapabilities }],
+		});
+		try {
+			await expect(harness.session.runRlmChild("bad effort", { effort: "ultra" })).rejects.toThrow(
+				"rlm.run effort must be one of off, minimal, low, medium, high, xhigh, max",
+			);
+			await expect(harness.session.runRlmChild("bad type", { effort: 3 })).rejects.toThrow(
+				"rlm.run effort must be a string",
+			);
+			await expect(harness.session.runRlmChild("unknown option", { temperature: 0 })).rejects.toThrow(
+				"Unsupported rlm.run kwargs: temperature",
+			);
+			await expect(harness.session.runRlmChild("wrong name", { thinking: "xhigh" })).rejects.toThrow(
+				"Unsupported rlm.run kwargs: thinking",
+			);
+			expect((await harness.session.listRlmSubagents()).subagents).toEqual([]);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("returns supported reasoning levels on the spawn-time find_models host path", async () => {
+		const harness = await createHarness({
+			provider,
+			models: [
+				{
+					id: "parent-model",
+					reasoning: true,
+					reasoningCapabilities: grok45LikeCapabilities,
+				},
+				{
+					id: "opus-like",
+					name: "Opus Like",
+					reasoning: true,
+					reasoningCapabilities: opusLikeCapabilities,
+				},
+			],
+		});
+		try {
+			const handlers = (
+				harness.session as unknown as { _createKernelHostHandlers(): HostRequestHandlers }
+			)._createKernelHostHandlers();
+			const findModels = handlers["rlm.find_models"];
+			if (!findModels) throw new Error("Missing rlm.find_models host handler");
+
+			await expect(findModels({ query: "opus", limit: 5 })).resolves.toEqual({
+				models: [
+					{
+						provider,
+						id: "opus-like",
+						name: "Opus Like",
+						selector: `${provider}/opus-like`,
+						reasoning_levels: ["off", "low", "medium", "high", "xhigh", "max"],
+					},
+				],
+			});
+
+			const grokMatches = await harness.session.findRlmModels("parent", 8);
+			expect(grokMatches.models).toEqual([
+				{
+					provider,
+					id: "parent-model",
+					name: "parent-model",
+					selector: `${provider}/parent-model`,
+					reasoning_levels: ["low", "medium", "high"],
+				},
+			]);
+			expect(grokMatches.models[0]?.reasoning_levels).not.toContain("xhigh");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("exposes catalog Opus 5 xhigh and xAI Grok 4.5's real supported levels", () => {
+		const opus = getModel("anthropic", "claude-opus-5");
+		const grok45 = getModel("xai", "grok-4.5");
+		const opusMatches = findRlmModelMatches("opus 5", [opus], 8);
+		const grokMatches = findRlmModelMatches("grok 4.5", [grok45], 8);
+
+		expect(opusMatches[0]?.selector).toBe("anthropic/claude-opus-5");
+		expect(opusMatches[0]?.reasoning_levels).toEqual(getSupportedThinkingLevels(opus));
+		expect(opusMatches[0]?.reasoning_levels).toContain("xhigh");
+
+		expect(grokMatches[0]?.selector).toBe("xai/grok-4.5");
+		expect(grokMatches[0]?.reasoning_levels).toEqual(getSupportedThinkingLevels(grok45));
+		expect(grokMatches[0]?.reasoning_levels).toEqual(["low", "medium", "high"]);
+		expect(grokMatches[0]?.reasoning_levels).not.toContain("xhigh");
+	});
+});

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -109,8 +109,12 @@ describe("buildRlmPrompt", () => {
 
 		expect(prompt).toContain("await rlm.find_models(...)");
 		expect(prompt).toContain("exact returned selector");
-		expect(prompt).toContain("An unavailable requested model fails spawn");
-		expect(prompt).toContain("decide whether to retry or omit `model`");
+		expect(prompt).toContain("reasoning_levels");
+		expect(prompt).toContain("effort='xhigh'");
+		expect(prompt).toContain("off`/`minimal`/`low`/`medium`/`high`/`max");
+		expect(prompt).toContain("An unavailable model or unsupported effort fails spawn");
+		expect(prompt).toContain("decide whether to retry or omit `model`/`effort`");
+		expect(prompt).toContain("Unknown `rlm.run` options fail");
 		expect(prompt).not.toContain("model choices for subagents");
 	});
 

--- a/prime-agent-runtime/src/rlm/__init__.py
+++ b/prime-agent-runtime/src/rlm/__init__.py
@@ -38,6 +38,7 @@ class RLMModel:
     id: str
     name: str
     selector: str
+    reasoning_levels: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -144,6 +145,8 @@ async def run(prompt: str, **kwargs: Any) -> RLMSpawnHandle:
     """Spawn a recursive Prime Agent child and return once its task is admitted.
 
     ``model`` selects a child with an exact ``provider/model`` selector.
+    ``effort`` sets the child's reasoning level when the selected model supports it.
+    Omitted ``effort`` inherits the parent level clamped to the child model.
     """
     if not isinstance(prompt, str):
         raise TypeError(f"prompt must be str, got {type(prompt).__name__}")
@@ -158,13 +161,27 @@ def _model_from_payload(payload: Any) -> RLMModel:
     model_id = payload.get("id")
     name = payload.get("name")
     selector = payload.get("selector")
+    reasoning_levels = payload.get("reasoning_levels")
     if not all(isinstance(value, str) and value for value in (provider, model_id, name, selector)):
         raise RuntimeError("rlm.find_models returned an invalid model entry")
-    return RLMModel(provider=provider, id=model_id, name=name, selector=selector)
+    if not isinstance(reasoning_levels, list) or not all(
+        isinstance(level, str) and level for level in reasoning_levels
+    ):
+        raise RuntimeError("rlm.find_models returned an invalid model entry")
+    return RLMModel(
+        provider=provider,
+        id=model_id,
+        name=name,
+        selector=selector,
+        reasoning_levels=tuple(reasoning_levels),
+    )
 
 
 async def find_models(query: str = "", limit: int = 8) -> list[RLMModel]:
-    """Search a bounded list of models backed by active user credentials."""
+    """Search a bounded list of models backed by active user credentials.
+
+    Each match includes ``reasoning_levels`` supported by that model.
+    """
     if not isinstance(query, str):
         raise TypeError(f"query must be str, got {type(query).__name__}")
     if not isinstance(limit, int):

--- a/prime-agent-runtime/test/test_subagent_registry.py
+++ b/prime-agent-runtime/test/test_subagent_registry.py
@@ -77,6 +77,7 @@ class RlmSubagentRegistryTest(unittest.TestCase):
                     "check the API",
                     name="api-reviewer",
                     model="deepseek/deepseek-v4-flash",
+                    effort="xhigh",
                 )
             )
 
@@ -87,6 +88,7 @@ class RlmSubagentRegistryTest(unittest.TestCase):
                 "kwargs": {
                     "name": "api-reviewer",
                     "model": "deepseek/deepseek-v4-flash",
+                    "effort": "xhigh",
                 },
             },
         )
@@ -103,6 +105,7 @@ class RlmSubagentRegistryTest(unittest.TestCase):
                         "id": "claude-opus-4-7",
                         "name": "Claude Opus 4.7",
                         "selector": "anthropic/claude-opus-4-7",
+                        "reasoning_levels": ["off", "low", "medium", "high", "xhigh", "max"],
                     }
                 ]
             }
@@ -115,6 +118,7 @@ class RlmSubagentRegistryTest(unittest.TestCase):
         self.assertEqual(models[0].id, "claude-opus-4-7")
         self.assertEqual(models[0].name, "Claude Opus 4.7")
         self.assertEqual(models[0].selector, "anthropic/claude-opus-4-7")
+        self.assertEqual(models[0].reasoning_levels, ("off", "low", "medium", "high", "xhigh", "max"))
         host_request.assert_awaited_once_with(
             "rlm.find_models",
             {"query": "opus", "limit": 3},


### PR DESCRIPTION
## Summary

Parents can now set a child's reasoning effort at spawn, and `rlm.find_models` returns each match's supported levels so a request like "subagent with opus 5 xhigh" is actionable.

- `rlm.run(..., effort="xhigh")` applies that level when the selected child model supports it
- Omitted `effort` still inherits the parent level clamped to the child model
- Unsupported or unknown effort fails at admission and starts no child
- Unknown kwargs still fail loudly (`thinking=` is not an alias)
- Each `rlm.find_models` match includes `reasoning_levels` (Opus 5 lists `xhigh`; xAI Grok 4.5 lists `low`/`medium`/`high`, not invented `xhigh`)
- RLM system prompt and spawn-option docs describe the contract

## Test plan

- [x] `packages/coding-agent` `test/suite/subagent-reasoning-effort.test.ts` (apply / inherit+clamp / reject / find_models / catalog metadata), run twice
- [x] `4649-subagent-model-selection.test.ts` and `system-prompt.test.ts`
- [x] `prime-agent-runtime` `test_subagent_registry.py`
- [x] `npm run check`
