### PR TITLE
fix(coding-agent): default grok subscription subagents to /fast

### DIFF
--- a/packages/ai/test/grok-responses-stream.test.ts
+++ b/packages/ai/test/grok-responses-stream.test.ts
@@ -182,24 +182,27 @@ describe("grok-responses provider", () => {
 		expect(capturedBody?.reasoning).toMatchObject({ effort: "medium" });
 	});
 
-	it("maps the priority service tier to grok fast mode (low effort, no service_tier)", async () => {
-		const model = getModel("grok", "grok-4.6");
-		let capturedBody: Record<string, unknown> | undefined;
+	it.each(["high", "xhigh"] as const)(
+		"maps the priority service tier plus %s reasoning to grok fast mode (low effort, no service_tier)",
+		async (reasoning) => {
+			const model = getModel("grok", "grok-4.6");
+			let capturedBody: Record<string, unknown> | undefined;
 
-		vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
-			capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
-			return sseResponse();
-		});
+			vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+				capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				return sseResponse();
+			});
 
-		await streamSimpleGrokResponses(model, buildContext(), {
-			apiKey: "grok-oauth-token",
-			reasoning: "high",
-			serviceTier: "priority",
-		}).result();
+			await streamSimpleGrokResponses(model, buildContext(), {
+				apiKey: "grok-oauth-token",
+				reasoning,
+				serviceTier: "priority",
+			}).result();
 
-		expect(capturedBody?.reasoning).toMatchObject({ effort: "low" });
-		expect(capturedBody?.service_tier).toBeUndefined();
-	});
+			expect(capturedBody?.reasoning).toMatchObject({ effort: "low" });
+			expect(capturedBody?.service_tier).toBeUndefined();
+		},
+	);
 
 	it("ignores non-priority service tiers for reasoning effort", async () => {
 		const model = getModel("grok", "grok-4.6");

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Changed Grok 4.5 and Grok 4.6 subagents on the grok provider to default to `/fast` regardless of parent service tier or spawn reasoning effort.
 - Added OrcaRouter as a built-in OpenAI-compatible provider with ORCAROUTER_API_KEY / ORCA_KEY authentication and orcarouter/auto as the default model.
 - Fixed deleting an RLM child leaving descendant spawn-ledger edges live after the child was tombstoned.
 - Fixed leftover Windows session leases blocking resume with `EPERM` when the previous owner process is gone.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -231,6 +231,7 @@ import {
 	type RlmSpawnHandle,
 	type RlmSubagentRegistryEntry,
 	type RlmSubagentRuntime,
+	resolveRlmSubagentServiceTier,
 	resolveRlmSubagentThinkingLevel,
 	type SubagentRuntimeHost,
 } from "./rlm-runtime.js";
@@ -9109,8 +9110,7 @@ export class AgentSession {
 			sessionDir: options.sessionDir,
 			model: options.model,
 			thinkingLevel: options.thinkingLevel,
-			serviceTier:
-				this.serviceTier === "priority" && !supportsFastMode(options.model) ? "default" : this.serviceTier,
+			serviceTier: resolveRlmSubagentServiceTier(options.model, this.serviceTier),
 			scopedModels: [...this._scopedModels],
 			activeToolNames: this.getActiveToolNames(),
 			allowedToolNames: this._allowedToolNames ? [...this._allowedToolNames] : undefined,

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -5,6 +5,7 @@ import {
 	getSupportedThinkingLevels,
 	type Model,
 	type ServiceTier,
+	supportsFastMode,
 } from "@earendil-works/pi-ai";
 import type { AgentSession } from "./agent-session.js";
 import type { ToolDefinition } from "./extensions/index.js";
@@ -140,6 +141,14 @@ export function resolveRlmSubagentThinkingLevel(
 		);
 	}
 	return requestedEffort;
+}
+
+/** Default grok-subscription `/fast` models to priority; otherwise inherit parent, clamped to model support. */
+export function resolveRlmSubagentServiceTier(model: Model<Api>, parentServiceTier: ServiceTier): ServiceTier {
+	if (model.provider === "grok" && supportsFastMode(model)) {
+		return "priority";
+	}
+	return parentServiceTier === "priority" && !supportsFastMode(model) ? "default" : parentServiceTier;
 }
 
 /** Create a readable, collision-resistant default name usable as an agent-message selector. */

--- a/packages/coding-agent/test/suite/regressions/4620-fast-mode-child-agents.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4620-fast-mode-child-agents.test.ts
@@ -1,5 +1,6 @@
-import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { fauxAssistantMessage, getModel, supportsFastMode } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
+import { resolveRlmSubagentServiceTier } from "../../../src/core/rlm-runtime.js";
 import { SessionManager } from "../../../src/core/session-manager.js";
 import { startSideQuestion } from "../../../src/core/side-question.js";
 import type { DaemonSocketClient } from "../../../src/modes/daemon/active-session-state.js";
@@ -16,6 +17,50 @@ const fastModel = {
 	api: "openai-codex-responses",
 	provider: "openai-codex",
 	models: [{ id: "gpt-5.4" }],
+};
+
+const grok46Capabilities = {
+	control: "effort" as const,
+	levels: {
+		off: null,
+		minimal: null,
+		low: "low",
+		medium: "medium",
+		high: "high",
+		xhigh: "xhigh",
+		max: null,
+	},
+};
+
+const grok45Capabilities = {
+	control: "effort" as const,
+	levels: {
+		off: null,
+		minimal: null,
+		low: "low",
+		medium: "medium",
+		high: "high",
+		xhigh: null,
+		max: null,
+	},
+};
+
+const grokSubscriptionHarness = {
+	api: "grok-responses",
+	provider: "grok",
+	models: [
+		{
+			id: "grok-4.6",
+			reasoning: true,
+			reasoningCapabilities: grok46Capabilities,
+		},
+		{
+			id: "grok-4.5",
+			reasoning: true,
+			reasoningCapabilities: grok45Capabilities,
+		},
+		{ id: "grok-code-fast-1", reasoning: false },
+	],
 };
 
 interface SupervisorHarness {
@@ -107,6 +152,172 @@ describe("ENG-4620 fast mode child agents", () => {
 			const childSessions = await SessionManager.list(harness.tempDir, result.session_dir!);
 			const childSession = SessionManager.open(childSessions[0]!.path, result.session_dir!);
 			expect(childSession.buildSessionContext().serviceTier).toBe("priority");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("resolves grok-subscription fast models to priority from catalog entries", () => {
+		expect(supportsFastMode(getModel("grok", "grok-4.6"))).toBe(true);
+		expect(supportsFastMode(getModel("grok", "grok-4.5"))).toBe(true);
+		expect(resolveRlmSubagentServiceTier(getModel("grok", "grok-4.6"), "default")).toBe("priority");
+		expect(resolveRlmSubagentServiceTier(getModel("grok", "grok-4.5"), "default")).toBe("priority");
+		expect(resolveRlmSubagentServiceTier(getModel("grok", "grok-4.6"), "priority")).toBe("priority");
+		expect(resolveRlmSubagentServiceTier(getModel("xai", "grok-4.6"), "default")).toBe("default");
+		expect(resolveRlmSubagentServiceTier(getModel("grok", "grok-4.3"), "default")).toBe("default");
+		expect(resolveRlmSubagentServiceTier(getModel("grok", "grok-code-fast-1"), "default")).toBe("default");
+		expect(resolveRlmSubagentServiceTier(getModel("openai-codex", "gpt-5.4"), "default")).toBe("default");
+		expect(resolveRlmSubagentServiceTier(getModel("openai-codex", "gpt-5.4"), "priority")).toBe("priority");
+	});
+
+	it("defaults grok-4.6 grok-provider children to fast when the parent is not fast and effort is inherited high", async () => {
+		const harness = await createHarness(grokSubscriptionHarness);
+		try {
+			expect(harness.session.serviceTier).toBe("default");
+			expect(supportsFastMode(harness.session.model!)).toBe(true);
+			harness.session.setThinkingLevel("high");
+			harness.setResponses([
+				(_context, options) => {
+					expect(options?.serviceTier).toBe("priority");
+					return fauxAssistantMessage("inherited high child");
+				},
+			]);
+
+			const result = await harness.session.runRlmChild("review at inherited high");
+			await vi.waitFor(() => {
+				expect(harness.session.getRlmChildSession(result.rlm_child_id)?.getLastAssistantText()).toBe(
+					"inherited high child",
+				);
+			});
+
+			const child = harness.session.getRlmChildSession(result.rlm_child_id);
+			expect(harness.session.serviceTier).toBe("default");
+			expect(child?.serviceTier).toBe("priority");
+			expect(child?.thinkingLevel).toBe("high");
+			expect(child?.model?.provider).toBe("grok");
+			expect(child?.model?.id).toBe("grok-4.6");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("defaults grok-4.6 grok-provider children to fast when rlm.run sets a non-low effort", async () => {
+		const harness = await createHarness(grokSubscriptionHarness);
+		try {
+			expect(harness.session.serviceTier).toBe("default");
+			harness.session.setThinkingLevel("medium");
+			harness.setResponses([
+				(_context, options) => {
+					expect(options?.serviceTier).toBe("priority");
+					return fauxAssistantMessage("explicit xhigh child");
+				},
+			]);
+
+			const result = await harness.session.runRlmChild("review at xhigh", { effort: "xhigh" });
+			await vi.waitFor(() => {
+				expect(harness.session.getRlmChildSession(result.rlm_child_id)?.getLastAssistantText()).toBe(
+					"explicit xhigh child",
+				);
+			});
+
+			const child = harness.session.getRlmChildSession(result.rlm_child_id);
+			expect(harness.session.serviceTier).toBe("default");
+			expect(harness.session.thinkingLevel).toBe("medium");
+			expect(child?.serviceTier).toBe("priority");
+			expect(child?.thinkingLevel).toBe("xhigh");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("defaults grok-4.5 grok-provider children to fast at a non-low inherited effort", async () => {
+		const harness = await createHarness(grokSubscriptionHarness);
+		try {
+			harness.session.setThinkingLevel("high");
+			harness.setResponses([
+				(_context, options) => {
+					expect(options?.serviceTier).toBe("priority");
+					return fauxAssistantMessage("grok-4.5 child");
+				},
+			]);
+
+			const result = await harness.session.runRlmChild("review as grok-4.5", { model: "grok/grok-4.5" });
+			await vi.waitFor(() => {
+				expect(harness.session.getRlmChildSession(result.rlm_child_id)?.getLastAssistantText()).toBe(
+					"grok-4.5 child",
+				);
+			});
+
+			const child = harness.session.getRlmChildSession(result.rlm_child_id);
+			expect(child?.serviceTier).toBe("priority");
+			expect(child?.thinkingLevel).toBe("high");
+			expect(child?.model?.id).toBe("grok-4.5");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("does not force fast on xai grok-4.6 children when the parent is default", async () => {
+		const harness = await createHarness({
+			api: "openai-completions",
+			provider: "xai",
+			models: [
+				{
+					id: "grok-4.6",
+					reasoning: true,
+					reasoningCapabilities: grok46Capabilities,
+				},
+			],
+		});
+		try {
+			expect(supportsFastMode(harness.session.model!)).toBe(false);
+			expect(harness.session.serviceTier).toBe("default");
+			harness.session.setThinkingLevel("high");
+			harness.setResponses([
+				(_context, options) => {
+					expect(options?.serviceTier).toBe("default");
+					return fauxAssistantMessage("xai child");
+				},
+			]);
+
+			const result = await harness.session.runRlmChild("review without grok subscription fast");
+			await vi.waitFor(() => {
+				expect(harness.session.getRlmChildSession(result.rlm_child_id)?.getLastAssistantText()).toBe("xai child");
+			});
+
+			const child = harness.session.getRlmChildSession(result.rlm_child_id);
+			expect(child?.serviceTier).toBe("default");
+			expect(child?.model?.provider).toBe("xai");
+			expect(child?.model?.id).toBe("grok-4.6");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("does not force fast on grok children that do not support /fast", async () => {
+		const harness = await createHarness(grokSubscriptionHarness);
+		try {
+			expect(harness.session.serviceTier).toBe("default");
+			harness.setResponses([
+				(_context, options) => {
+					expect(options?.serviceTier).toBe("default");
+					return fauxAssistantMessage("code-fast child");
+				},
+			]);
+
+			const result = await harness.session.runRlmChild("use the non-fast grok model", {
+				model: "grok/grok-code-fast-1",
+			});
+			await vi.waitFor(() => {
+				expect(harness.session.getRlmChildSession(result.rlm_child_id)?.getLastAssistantText()).toBe(
+					"code-fast child",
+				);
+			});
+
+			const child = harness.session.getRlmChildSession(result.rlm_child_id);
+			expect(child?.serviceTier).toBe("default");
+			expect(child?.model?.id).toBe("grok-code-fast-1");
+			expect(supportsFastMode(child!.model!)).toBe(false);
 		} finally {
 			harness.cleanup();
 		}


### PR DESCRIPTION
Grok 4.5 and Grok 4.6 subagents on the `grok` provider (Grok CLI / SuperGrok) now default to `/fast` at spawn.

This applies even when the parent session is not in `/fast` and even when the child inherits or is given a non-low effort (`medium` / `high` / `xhigh`). Spawn sets `serviceTier` from the child model: grok-subscription models that already support `/fast` are admitted as `priority`. The existing grok stream mapping still turns `priority` into `low` effort on the same model id and omits `service_tier` on the wire.

Models that do not advertise grok-subscription fast (`xai` grok-4.6, grok-4.3, grok-code-fast-1, ChatGPT) keep parent inheritance. Top-level `/fast` preference is unchanged.
