### PR TITLE
fix(coding-agent): skip silent-complete notices for still-live children

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed the parent being told a still-live RLM child completed without sending a reply after the spawn turn ended ([#1637](https://github.com/PrimeIntellect-ai/prime-agent/issues/1637)).
 - Changed Grok 4.5 and Grok 4.6 subagents on the grok provider to default to `/fast` regardless of parent service tier or spawn reasoning effort.
 - Added OrcaRouter as a built-in OpenAI-compatible provider with ORCAROUTER_API_KEY / ORCA_KEY authentication and orcarouter/auto as the default model.
 - Fixed deleting an RLM child leaving descendant spawn-ledger edges live after the child was tombstoned.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9347,10 +9347,11 @@ export class AgentSession {
 		return this._rlmHeartbeatController?.listRlmHeartbeats().some((job) => job.status === "active") === true;
 	}
 
-	/** True when this session still has in-flight work, queued work, an active heartbeat, or live descendants. */
+	/** True when this session still has in-flight work, queued work, pending admission, an active heartbeat, or live descendants. */
 	hasLiveRlmSessionWork(): boolean {
 		return (
 			this.isSessionActive ||
+			this.hasPendingAdmissionWaiters ||
 			this.agent.hasQueuedMessages() ||
 			this.hasRunningRlmChildren() ||
 			this._hasActiveRlmHeartbeat()

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9343,6 +9343,48 @@ export class AgentSession {
 		return false;
 	}
 
+	private _hasActiveRlmHeartbeat(): boolean {
+		return this._rlmHeartbeatController?.listRlmHeartbeats().some((job) => job.status === "active") === true;
+	}
+
+	/** True when this session still has in-flight work, queued work, an active heartbeat, or live descendants. */
+	hasLiveRlmSessionWork(): boolean {
+		return (
+			this.isSessionActive ||
+			this.agent.hasQueuedMessages() ||
+			this.hasRunningRlmChildren() ||
+			this._hasActiveRlmHeartbeat()
+		);
+	}
+
+	private async _waitWhileRlmChildLive(child: AgentSession, run: RlmChildRun): Promise<void> {
+		if (run.status === "cancelled" || this._disposed || this._disposing || !child.hasLiveRlmSessionWork()) {
+			return;
+		}
+		await new Promise<void>((resolve) => {
+			let settled = false;
+			const finish = () => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				clearInterval(timer);
+				unsubscribe();
+				resolve();
+			};
+			const check = () => {
+				if (run.status === "cancelled" || this._disposed || this._disposing || !child.hasLiveRlmSessionWork()) {
+					finish();
+				}
+			};
+			const unsubscribe = child.subscribe(() => {
+				check();
+			});
+			const timer = setInterval(check, 20);
+			check();
+		});
+	}
+
 	getRlmChildSession(childId: string): AgentSession | undefined {
 		const direct = this._activeRlmChildRuns.get(childId)?.session ?? this._rlmChildSessions.get(childId);
 		if (direct) {
@@ -9708,6 +9750,9 @@ export class AgentSession {
 					source: "extension",
 					customMessage: spawnMessage,
 				});
+				// First spawn turn ending is not child death; leftover work can still be live.
+				await this._waitWhileRlmChildLive(child, run);
+				throwIfCancelled();
 				if (run.error) throw new Error(run.error);
 				run.status = "done";
 				durationMs = Date.now() - startedAt;

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -212,6 +212,23 @@ async function waitFor(condition: () => boolean): Promise<void> {
 	}
 }
 
+function completedWithoutReplyContents(root: AgentSession): string[] {
+	return root.messages
+		.map((message) => ("content" in message ? message.content : undefined))
+		.filter(
+			(content): content is string =>
+				typeof content === "string" && content.includes("completed without sending a reply"),
+		);
+}
+
+async function expectNoCompletedWithoutReply(root: AgentSession, durationMs = 100): Promise<void> {
+	const deadline = Date.now() + durationMs;
+	while (Date.now() < deadline) {
+		expect(completedWithoutReplyContents(root)).toEqual([]);
+		await sleep(10);
+	}
+}
+
 async function expectSettlesWithin(promise: Promise<void>, timeoutMs: number): Promise<void> {
 	const result = await Promise.race([
 		promise.then(() => "settled" as const),
@@ -254,6 +271,7 @@ describe("AgentSession rlm recursion", () => {
 			agentMessageController?: AgentSessionMessageController;
 			subagentRuntimeHost?: SubagentRuntimeHost;
 			customTools?: ConstructorParameters<typeof AgentSession>[0]["customTools"];
+			rlmHeartbeatController?: ConstructorParameters<typeof AgentSession>[0]["rlmHeartbeatController"];
 			rlmSessionDir?: string;
 			sessionManager?: SessionManager;
 			settingsManager?: SettingsManager;
@@ -305,6 +323,7 @@ describe("AgentSession rlm recursion", () => {
 					: undefined,
 			}),
 			agentMessageController: options.agentMessageController,
+			rlmHeartbeatController: options.rlmHeartbeatController,
 			subagentRuntimeHost: options.subagentRuntimeHost,
 			customTools: options.customTools,
 			rlmDepth: options.depth,
@@ -1241,6 +1260,275 @@ describe("AgentSession rlm recursion", () => {
 		});
 	});
 
+	it("does not notice a silent child while a nested descendant is still running", async () => {
+		let releaseChild = () => {};
+		const childGate = new Promise<void>((resolve) => {
+			releaseChild = resolve;
+		});
+		let releaseNested = () => {};
+		const nestedGate = new Promise<void>((resolve) => {
+			releaseNested = resolve;
+		});
+		let childStarted = false;
+		let nestedStarted = false;
+		const nested = createSession({
+			depth: 2,
+			rlmSessionDir: join(tempDir, "live-nested"),
+			streamFn: () => {
+				nestedStarted = true;
+				const stream = createAssistantMessageEventStream();
+				void nestedGate.then(() => {
+					stream.push({ type: "done", reason: "stop", message: assistantMessage("nested still working") });
+				});
+				return stream;
+			},
+		});
+		const child = createSession({
+			depth: 1,
+			maxDepth: 2,
+			rlmSessionDir: join(tempDir, "live-child"),
+			streamFn: (_model, context) => {
+				const text = userText(context);
+				if (text === "silent parent") {
+					childStarted = true;
+					const stream = createAssistantMessageEventStream();
+					void childGate.then(() => {
+						stream.push({ type: "done", reason: "stop", message: assistantMessage("child first turn") });
+					});
+					return stream;
+				}
+				return streamAnswer(`later: ${text}`);
+			},
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: nested }),
+				deleteRlmSubagentRuntime: async () => {},
+			},
+		});
+		const completeRlmSubagentRuntime = vi.fn(() => true);
+		const root = createSession({
+			maxDepth: 2,
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: child }),
+				completeRlmSubagentRuntime,
+				deleteRlmSubagentRuntime: async () => {},
+			},
+		});
+
+		const spawned = await root.runRlmChild("silent parent", { name: "silent-parent" });
+		await waitFor(() => childStarted);
+		await child.runRlmChild("nested worker", { name: "nested-worker" });
+		await waitFor(() => nestedStarted);
+		releaseChild();
+		await waitFor(() => child.getLastAssistantText() !== undefined);
+		await expectNoCompletedWithoutReply(root);
+		expect(root.getRlmChildRunStatus(spawned.rlm_child_id)).toBe("running");
+		expect(completeRlmSubagentRuntime).not.toHaveBeenCalled();
+		expect(child.hasLiveRlmSessionWork()).toBe(true);
+		expect((await root.listRlmSubagents()).subagents).toContainEqual(
+			expect.objectContaining({ rlm_child_id: spawned.rlm_child_id, status: "running" }),
+		);
+
+		releaseNested();
+		await vi.waitFor(() => {
+			expect(completedWithoutReplyContents(root)).toHaveLength(1);
+		});
+		expect(completedWithoutReplyContents(root)[0]).toContain(
+			`RLM child silent-parent (${spawned.rlm_child_id}) completed without sending a reply`,
+		);
+		expect(completeRlmSubagentRuntime).toHaveBeenCalledWith(spawned.rlm_child_id, child);
+		expect((await root.listRlmSubagents()).subagents).toContainEqual(
+			expect.objectContaining({ rlm_child_id: spawned.rlm_child_id, status: "completed" }),
+		);
+	});
+
+	it("does not notice a silent child while a follow-up turn remains", async () => {
+		let releaseFirst = () => {};
+		const firstGate = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		let releaseFollowUp = () => {};
+		const followUpGate = new Promise<void>((resolve) => {
+			releaseFollowUp = resolve;
+		});
+		let firstStarted = false;
+		let followUpStarted = false;
+		const child = createSession({
+			depth: 1,
+			rlmSessionDir: join(tempDir, "follow-up-child"),
+			streamFn: (_model, context) => {
+				const text = userText(context);
+				if (text === "silent with follow-up") {
+					firstStarted = true;
+					const stream = createAssistantMessageEventStream();
+					void firstGate.then(() => {
+						stream.push({ type: "done", reason: "stop", message: assistantMessage("first turn") });
+					});
+					return stream;
+				}
+				followUpStarted = true;
+				const stream = createAssistantMessageEventStream();
+				void followUpGate.then(() => {
+					stream.push({ type: "done", reason: "stop", message: assistantMessage(`follow-up: ${text}`) });
+				});
+				return stream;
+			},
+		});
+		const completeRlmSubagentRuntime = vi.fn(() => true);
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: child }),
+				completeRlmSubagentRuntime,
+				deleteRlmSubagentRuntime: async () => {},
+			},
+		});
+
+		const spawned = await root.runRlmChild("silent with follow-up", { name: "follow-up-worker" });
+		await waitFor(() => firstStarted);
+		await child.promptUntilAccepted("keep going", { streamingBehavior: "followUp" });
+		releaseFirst();
+		await waitFor(() => followUpStarted);
+		await expectNoCompletedWithoutReply(root);
+		expect(root.getRlmChildRunStatus(spawned.rlm_child_id)).toBe("running");
+		expect(completeRlmSubagentRuntime).not.toHaveBeenCalled();
+		expect(child.hasLiveRlmSessionWork()).toBe(true);
+
+		releaseFollowUp();
+		await vi.waitFor(() => {
+			expect(completedWithoutReplyContents(root)).toHaveLength(1);
+		});
+		expect(completeRlmSubagentRuntime).toHaveBeenCalledWith(spawned.rlm_child_id, child);
+	});
+
+	it("does not notice a silent child while an active heartbeat remains", async () => {
+		const heartbeats: Array<{ status: "active" | "paused" }> = [{ status: "active" }];
+		const child = createSession({
+			depth: 1,
+			rlmSessionDir: join(tempDir, "heartbeat-child"),
+			rlmHeartbeatController: {
+				listRlmHeartbeats: () => heartbeats as never,
+				createRlmHeartbeat: () => {
+					throw new Error("unused");
+				},
+				updateRlmHeartbeat: () => undefined,
+				deleteRlmHeartbeat: () => undefined,
+			},
+		});
+		const completeRlmSubagentRuntime = vi.fn(() => true);
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: child }),
+				completeRlmSubagentRuntime,
+				deleteRlmSubagentRuntime: async () => {},
+			},
+		});
+
+		const spawned = await root.runRlmChild("silent heartbeat child", { name: "heartbeat-worker" });
+		await waitFor(() => child.getLastAssistantText() !== undefined);
+		await expectNoCompletedWithoutReply(root);
+		expect(root.getRlmChildRunStatus(spawned.rlm_child_id)).toBe("running");
+		expect(completeRlmSubagentRuntime).not.toHaveBeenCalled();
+		expect(child.hasLiveRlmSessionWork()).toBe(true);
+
+		heartbeats.length = 0;
+		await vi.waitFor(() => {
+			expect(completedWithoutReplyContents(root)).toHaveLength(1);
+		});
+		expect(completeRlmSubagentRuntime).toHaveBeenCalledWith(spawned.rlm_child_id, child);
+	});
+
+	it("does not notice a child that replied while leftover nested work was still live", async () => {
+		let releaseChild = () => {};
+		const childGate = new Promise<void>((resolve) => {
+			releaseChild = resolve;
+		});
+		let releaseNested = () => {};
+		const nestedGate = new Promise<void>((resolve) => {
+			releaseNested = resolve;
+		});
+		let childStarted = false;
+		let nestedStarted = false;
+		const nested = createSession({
+			depth: 2,
+			rlmSessionDir: join(tempDir, "replied-nested"),
+			streamFn: () => {
+				nestedStarted = true;
+				const stream = createAssistantMessageEventStream();
+				void nestedGate.then(() => {
+					stream.push({ type: "done", reason: "stop", message: assistantMessage("nested done") });
+				});
+				return stream;
+			},
+		});
+		const child = createSession({
+			depth: 1,
+			maxDepth: 2,
+			rlmSessionDir: join(tempDir, "replied-live-child"),
+			agentMessageController: {
+				listAgents: () => ({ agents: [] }),
+				roster: () => ({
+					current: { name: "reply-live-worker", id: child.sessionId, depth: 1 },
+					entries: [
+						{
+							relationship: "parent",
+							name: "parent",
+							id: "parent-session",
+							depth: 0,
+							status: "idle",
+						},
+					],
+				}),
+				sendAgentMessage: async () => ({
+					id: "agentmsg-reply-while-live",
+					source: "agent_message",
+					target: { activeSessionId: "parent-active", sessionId: "parent-session" },
+					message: "still working",
+					deliveryStatus: "delivered",
+				}),
+			},
+			streamFn: (_model, context) => {
+				const text = userText(context);
+				if (text === "reply while live") {
+					childStarted = true;
+					const stream = createAssistantMessageEventStream();
+					void childGate.then(() => {
+						stream.push({ type: "done", reason: "stop", message: assistantMessage("child first turn") });
+					});
+					return stream;
+				}
+				return streamAnswer(`later: ${text}`);
+			},
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: nested }),
+				deleteRlmSubagentRuntime: async () => {},
+			},
+		});
+		const root = createSession({
+			maxDepth: 2,
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: child }),
+				completeRlmSubagentRuntime: () => true,
+				deleteRlmSubagentRuntime: async () => {},
+			},
+		});
+
+		const spawned = await root.runRlmChild("reply while live", { name: "reply-live-worker" });
+		await waitFor(() => childStarted);
+		await child.runRlmChild("nested worker");
+		await waitFor(() => nestedStarted);
+		const send = (child as unknown as InspectableRlmSession)._createKernelHostHandlers()["agent_message.send"];
+		if (!send) throw new Error("Missing agent_message.send host handler");
+		await send({ message: "still working", receiver_role: "parent" });
+		releaseChild();
+		await expectNoCompletedWithoutReply(root);
+		releaseNested();
+		await vi.waitFor(async () => {
+			expect((await root.listRlmSubagents()).subagents).toContainEqual(
+				expect.objectContaining({ rlm_child_id: spawned.rlm_child_id, status: "completed" }),
+			);
+		});
+		expect(completedWithoutReplyContents(root)).toHaveLength(0);
+	});
+
 	it("does not inject a terminal notice when a parent follow-up resets reply state after a reply", async () => {
 		const child = createSession({
 			depth: 1,
@@ -1281,12 +1569,8 @@ describe("AgentSession rlm recursion", () => {
 			},
 		});
 
-		const spawned = await root.runRlmChild("reply first", { name: "reply-worker" });
-		await vi.waitFor(async () => {
-			expect((await root.listRlmSubagents()).subagents).toContainEqual(
-				expect.objectContaining({ rlm_child_id: spawned.rlm_child_id, status: "completed" }),
-			);
-		});
+		await root.runRlmChild("reply first", { name: "reply-worker" });
+		await expectNoCompletedWithoutReply(root);
 		expect(
 			root.messages.filter(
 				(message) => message.role === "custom" && message.customType === "rlm_child_terminal_notice",
@@ -2139,6 +2423,9 @@ describe("AgentSession rlm recursion", () => {
 	it("lets a stale kernel depth cap defer to the live host gate", () => {
 		const python =
 			process.env.PRIME_AGENT_KERNEL_PYTHON ?? join(homedir(), ".prime", "agent", "kernel-venv", "bin", "python");
+		if (!existsSync(python)) {
+			return;
+		}
 		const runtime = join(process.cwd(), "..", "..", "prime-agent-runtime", "src");
 		const probe = spawnSync(
 			python,
@@ -2868,6 +3155,10 @@ describe("AgentSession rlm recursion", () => {
 				} else if (text === "nested shard") {
 					nestedStarted = true;
 					void nestedRelease.then(() => {
+						stream.push({ type: "done", reason: "stop", message: assistantMessage(`child answer: ${text}`) });
+					});
+				} else {
+					queueMicrotask(() => {
 						stream.push({ type: "done", reason: "stop", message: assistantMessage(`child answer: ${text}`) });
 					});
 				}

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -131,7 +131,9 @@ interface InspectableRlmSession {
 	_rlmChildCleanupFailures: Map<string, Awaited<ReturnType<AgentSession["listRlmSubagents"]>>["subagents"][number]>;
 	_rlmChildSessions: Map<string, AgentSession>;
 	_rlmChildUnsubscribes: Map<string, () => void>;
+	_pendingSessionActionFenceWaiters: number;
 	_createKernelHostHandlers(): HostRequestHandlers;
+	_acquireDirectTurnAdmissionFence(signal?: AbortSignal): Promise<{ release(): void }>;
 	_reapDeletedRlmSubagentRuntimesAfterCompaction(): Promise<void>;
 }
 
@@ -1397,6 +1399,81 @@ describe("AgentSession rlm recursion", () => {
 			expect(completedWithoutReplyContents(root)).toHaveLength(1);
 		});
 		expect(completeRlmSubagentRuntime).toHaveBeenCalledWith(spawned.rlm_child_id, child);
+	});
+
+	it("does not notice a silent child while a follow-up waits on the admission fence", async () => {
+		let releaseFirst = () => {};
+		const firstGate = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		let releaseFollowUp = () => {};
+		const followUpGate = new Promise<void>((resolve) => {
+			releaseFollowUp = resolve;
+		});
+		let firstStarted = false;
+		let followUpStarted = false;
+		const child = createSession({
+			depth: 1,
+			rlmSessionDir: join(tempDir, "admission-fence-child"),
+			streamFn: (_model, context) => {
+				const text = userText(context);
+				if (text === "silent with fenced follow-up") {
+					firstStarted = true;
+					const stream = createAssistantMessageEventStream();
+					void firstGate.then(() => {
+						stream.push({ type: "done", reason: "stop", message: assistantMessage("first turn") });
+					});
+					return stream;
+				}
+				followUpStarted = true;
+				const stream = createAssistantMessageEventStream();
+				void followUpGate.then(() => {
+					stream.push({ type: "done", reason: "stop", message: assistantMessage(`follow-up: ${text}`) });
+				});
+				return stream;
+			},
+		});
+		const completeRlmSubagentRuntime = vi.fn(() => true);
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: child }),
+				completeRlmSubagentRuntime,
+				deleteRlmSubagentRuntime: async () => {},
+			},
+		});
+		const internals = child as unknown as InspectableRlmSession;
+
+		const spawned = await root.runRlmChild("silent with fenced follow-up", { name: "fenced-worker" });
+		await waitFor(() => firstStarted);
+		const heldFence = await internals._acquireDirectTurnAdmissionFence();
+		try {
+			releaseFirst();
+			await waitFor(() => child.getLastAssistantText() !== undefined && !child.isSessionActive);
+			await expectNoCompletedWithoutReply(root);
+			expect(child.hasPendingAdmissionWaiters).toBe(true);
+			expect(child.hasLiveRlmSessionWork()).toBe(true);
+			expect(root.getRlmChildRunStatus(spawned.rlm_child_id)).toBe("running");
+			expect(completeRlmSubagentRuntime).not.toHaveBeenCalled();
+
+			const followUp = child.promptUntilAccepted("keep going");
+			await vi.waitFor(() => expect(internals._pendingSessionActionFenceWaiters).toBe(1));
+			await expectNoCompletedWithoutReply(root);
+			expect(followUpStarted).toBe(false);
+
+			heldFence.release();
+			await waitFor(() => followUpStarted);
+			await expectNoCompletedWithoutReply(root);
+			expect(completeRlmSubagentRuntime).not.toHaveBeenCalled();
+
+			releaseFollowUp();
+			await followUp;
+			await vi.waitFor(() => {
+				expect(completedWithoutReplyContents(root)).toHaveLength(1);
+			});
+			expect(completeRlmSubagentRuntime).toHaveBeenCalledWith(spawned.rlm_child_id, child);
+		} finally {
+			heldFence.release();
+		}
 	});
 
 	it("does not notice a silent child while an active heartbeat remains", async () => {

--- a/packages/coding-agent/test/suite/regressions/1637-subagent-false-completed-without-reply.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1637-subagent-false-completed-without-reply.test.ts
@@ -1,0 +1,165 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	AGENT_MESSAGE_CUSTOM_TYPE,
+	type AgentSessionMessage,
+	createAgentSessionMessage,
+} from "../../../src/core/agent-messages.js";
+import { createHarness, type Harness } from "../harness.js";
+
+function completedWithoutReplyMessages(messages: readonly unknown[]): unknown[] {
+	return messages.filter((message) => {
+		const content = (message as { content?: unknown }).content;
+		return typeof content === "string" && content.includes("completed without sending a reply");
+	});
+}
+
+function attributedTerminalMessage(messages: readonly unknown[]): AgentSessionMessage | undefined {
+	return messages.find((message): message is AgentSessionMessage => {
+		if (typeof message !== "object" || message === null) return false;
+		const content = "content" in message ? (message as { content?: unknown }).content : undefined;
+		return (
+			"role" in message &&
+			"customType" in message &&
+			(message as { role?: unknown }).role === "custom" &&
+			(message as { customType?: unknown }).customType === AGENT_MESSAGE_CUSTOM_TYPE &&
+			typeof content === "string" &&
+			content.includes("completed without sending a reply")
+		);
+	});
+}
+
+describe("#1637 still-live RLM children are not marked completed without reply", () => {
+	let parent: Harness | undefined;
+	let child: Harness | undefined;
+	let nested: Harness | undefined;
+
+	afterEach(() => {
+		nested?.cleanup();
+		child?.cleanup();
+		parent?.cleanup();
+		nested = undefined;
+		child = undefined;
+		parent = undefined;
+	});
+
+	it("holds the silent-completion notice until leftover nested work ends", async () => {
+		let releaseChild: (message: ReturnType<typeof fauxAssistantMessage>) => void = () => {};
+		const childGate = new Promise<ReturnType<typeof fauxAssistantMessage>>((resolve) => {
+			releaseChild = resolve;
+		});
+		let releaseNested: (message: ReturnType<typeof fauxAssistantMessage>) => void = () => {};
+		const nestedGate = new Promise<ReturnType<typeof fauxAssistantMessage>>((resolve) => {
+			releaseNested = resolve;
+		});
+		const completeChild = vi.fn(() => true);
+
+		nested = await createHarness();
+		nested.setResponses([async () => nestedGate]);
+		child = await createHarness({
+			rlmDepth: 1,
+			rlmMaxDepth: 2,
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: nested!.session }),
+				deleteRlmSubagentRuntime: async () => {},
+			},
+			agentMessageController: {
+				listAgents: () => ({ agents: [] }),
+				sendAgentMessage: async (input) => {
+					const message = createAgentSessionMessage({
+						id: `agentmsg-${Date.now()}`,
+						source: "agent_message",
+						message: input.message,
+						from: {
+							activeSessionId: "child-active",
+							sessionId: child!.session.sessionId,
+							sessionName: "finish2",
+						},
+						fromRelationship: "child",
+						target: { activeSessionId: "parent-active", sessionId: parent!.session.sessionId },
+					});
+					await parent!.session.acceptAgentMessagePrompt(message.content, { customMessage: message });
+					return {
+						id: message.details.id,
+						source: "agent_message",
+						target: { activeSessionId: "parent-active", sessionId: parent!.session.sessionId },
+						message: input.message,
+						deliveryStatus: "delivered",
+					};
+				},
+			},
+		});
+		child.setResponses([async () => childGate, fauxAssistantMessage("ack nested notice")]);
+		parent = await createHarness({
+			rlmDepth: 0,
+			rlmMaxDepth: 2,
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: child!.session }),
+				completeRlmSubagentRuntime: completeChild,
+				deleteRlmSubagentRuntime: async () => {},
+			},
+		});
+
+		const spawned = await parent.session.runRlmChild("finish without replying", { name: "finish2" });
+		await expect.poll(() => parent!.session.getRlmChildSession(spawned.rlm_child_id)).not.toBeUndefined();
+		await child.session.runRlmChild("still working", { name: "finish1" });
+		await expect.poll(() => nested!.session.isStreaming).toBe(true);
+
+		releaseChild(fauxAssistantMessage("child first turn"));
+		await expect.poll(() => child!.session.getLastAssistantText()).toBe("child first turn");
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(completedWithoutReplyMessages(parent.session.messages)).toHaveLength(0);
+		expect(parent.session.getRlmChildRunStatus(spawned.rlm_child_id)).toBe("running");
+		expect(completeChild).not.toHaveBeenCalled();
+		expect(child.session.hasLiveRlmSessionWork()).toBe(true);
+
+		releaseNested(fauxAssistantMessage("nested finished"));
+		await expect.poll(() => completedWithoutReplyMessages(parent!.session.messages)).toHaveLength(1);
+		expect(attributedTerminalMessage(parent.session.messages)?.content).toContain(spawned.rlm_child_id);
+		expect(completeChild).toHaveBeenCalledWith(spawned.rlm_child_id, child.session);
+	});
+
+	it("still notices a one-turn silent child", async () => {
+		child = await createHarness({
+			agentMessageController: {
+				listAgents: () => ({ agents: [] }),
+				sendAgentMessage: async (input) => {
+					const message = createAgentSessionMessage({
+						id: "agentmsg-silent-or-reply",
+						source: "agent_message",
+						message: input.message,
+						from: {
+							activeSessionId: "child-active",
+							sessionId: child!.session.sessionId,
+							sessionName: "one-turn-worker",
+						},
+						fromRelationship: "child",
+						target: { activeSessionId: "parent-active", sessionId: parent!.session.sessionId },
+					});
+					await parent!.session.acceptAgentMessagePrompt(message.content, { customMessage: message });
+					return {
+						id: message.details.id,
+						source: "agent_message",
+						target: { activeSessionId: "parent-active", sessionId: parent!.session.sessionId },
+						message: input.message,
+						deliveryStatus: "delivered",
+					};
+				},
+			},
+		});
+		parent = await createHarness({
+			rlmDepth: 0,
+			rlmMaxDepth: 1,
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: child!.session }),
+				deleteRlmSubagentRuntime: async () => {},
+			},
+		});
+		child.setResponses([fauxAssistantMessage("child completed")]);
+
+		const spawned = await parent.session.runRlmChild("finish without replying", { name: "one-turn-worker" });
+		await expect.poll(() => completedWithoutReplyMessages(parent!.session.messages).length).toBeGreaterThan(0);
+		expect(completedWithoutReplyMessages(parent.session.messages)).toHaveLength(1);
+		expect(attributedTerminalMessage(parent.session.messages)?.content).toContain(spawned.rlm_child_id);
+	});
+});


### PR DESCRIPTION
## Summary

RLM spawn treated the first spawn `promptAndWait` returning as child death. If that turn had no parent `agent_message` reply, the parent immediately got "completed without sending a reply" (attributed agent message or injected `rlm_child_terminal_notice`) and host completion settled — even when the child still had in-flight/queued work, an active heartbeat, or a running/queued descendant.

That is the false-death case: a sibling can look finished while it is still live.

## Behavior

- Spawn admission stays non-blocking.
- After the first spawn turn, wait until the child is actually idle (no live session work, no active heartbeat, no running/queued descendants) before delivering `completed_without_reply` or settling host completion.
- A truly idle silent child still gets exactly one notice via the existing #617 path.
- A child that replied still does not get the notice. Cancellation and failure notices are unchanged.

## Tests

- `packages/coding-agent/test/agent-session-recursion.test.ts` — still-live nested / follow-up / heartbeat, true idle after leftover work, replied-while-live, cancelled.
- `packages/coding-agent/test/suite/regressions/1637-subagent-false-completed-without-reply.test.ts` — faux-harness still-live nested vs one-turn silent.

Fixes #1637
