### PR TITLE
fix(coding-agent): allow deleting inactive non-resident sessions

### DIFF
--- a/packages/coding-agent/.changes/inactive-session-delete-false-active.md
+++ b/packages/coding-agent/.changes/inactive-session-delete-false-active.md
@@ -1,0 +1,1 @@
+- Fixed deleting Inactive agents-view rows that were not live-resident sessions, which previously failed with "Cannot delete the currently active session".

--- a/packages/coding-agent/.changes/inactive-session-delete-false-active.md
+++ b/packages/coding-agent/.changes/inactive-session-delete-false-active.md
@@ -1,1 +1,2 @@
 - Fixed deleting Inactive agents-view rows that were not live-resident sessions, which previously failed with "Cannot delete the currently active session".
+- Fixed a race that allowed deleting a session file while its daemon worker was still starting.

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1832,6 +1832,14 @@ export class AgentsViewMode implements Component, Focusable {
 		if (row.kind !== "agent") {
 			return;
 		}
+		// Scoped/orphaned passivated RLM children render as Inactive agent rows.
+		// Tombstone them through the subagent-delete command when parent+child ids
+		// are known; otherwise a saved-session file delete is enough.
+		if (!row.summary.activeSessionId && this.resolveInactiveRlmChildDeleteTarget(row)) {
+			this.pendingDeleteAgent = undefined;
+			await this.handleKillSubagentSelected(row);
+			return;
+		}
 		this.pendingKillSubagent = undefined;
 		const identity = getSummaryIdentity(row.summary);
 		if (!row.summary.activeSessionId && row.summary.sessionFile) {
@@ -1897,14 +1905,55 @@ export class AgentsViewMode implements Component, Focusable {
 			await this.killSubagent(pending, row);
 			return;
 		}
-		const childId = row.summary.rlmChildId;
-		const rootActiveSessionId = this.findSubagentRootRow(row)?.summary.activeSessionId;
-		if (!childId || !rootActiveSessionId) {
+		const target = this.resolveInactiveRlmChildDeleteTarget(row);
+		if (!target) {
 			this.setStatusMessage("Cannot stop subagent without its parent agent");
 			return;
 		}
-		this.pendingKillSubagent = { identity, rootActiveSessionId, childId };
+		this.pendingKillSubagent = {
+			identity,
+			rootActiveSessionId: target.rootActiveSessionId,
+			childId: target.childId,
+		};
 		this.showDeleteConfirmation();
+	}
+
+	/**
+	 * Nested subagent rows carry parentIdentity; scoped Inactive children are
+	 * shown as depth-0 agent rows, so parent identity comes from the summary,
+	 * the current scope root, or the last live list.
+	 */
+	private resolveInactiveRlmChildDeleteTarget(
+		row: AgentsViewRow,
+	): { rootActiveSessionId: string; childId: string } | undefined {
+		const childId = row.summary.rlmChildId;
+		if (!childId) return undefined;
+		const rootActiveSessionId = this.resolveRlmSubagentParentActiveSessionId(row);
+		if (!rootActiveSessionId) return undefined;
+		return { rootActiveSessionId, childId };
+	}
+
+	private resolveRlmSubagentParentActiveSessionId(row: AgentsViewRow): string | undefined {
+		const treeRoot = this.findSubagentRootRow(row)?.summary.activeSessionId;
+		if (treeRoot) return treeRoot;
+		if (row.summary.parentActiveSessionId) return row.summary.parentActiveSessionId;
+		const scoped = this.scopeRootSummary?.activeSessionId ?? this.scopeKey?.activeSessionId;
+		if (scoped) return scoped;
+		const parentSessionId = row.summary.parentSessionId;
+		const parentPath = row.summary.parentSessionPath;
+		if (!parentSessionId && !parentPath) return undefined;
+		for (const summary of this.lastListedSummaries) {
+			if (!summary.activeSessionId) continue;
+			if (parentSessionId && summary.sessionId === parentSessionId) return summary.activeSessionId;
+			if (
+				parentPath &&
+				summary.sessionFile &&
+				resolvePath(canonicalizePath(summary.sessionFile)) === resolvePath(canonicalizePath(parentPath))
+			) {
+				return summary.activeSessionId;
+			}
+		}
+		return undefined;
 	}
 
 	private async killSubagent(pending: PendingKillSubagent, currentRow: AgentsViewRow): Promise<void> {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -169,6 +169,7 @@ import {
 	buildRlmChildSnapshots,
 	buildSessionList,
 	classifySessionRosterStatus,
+	hasLiveResidentSessionFile,
 	inactiveLifecycleForSession,
 	isActiveSessionBusy,
 	type SessionSummary,
@@ -4202,7 +4203,15 @@ export class AgentDaemon {
 				if (command.activeSessionId) {
 					this.getSessionState(command.activeSessionId);
 				}
-				if (this.findActiveSessionByFile(command.sessionPath)) {
+				if (
+					hasLiveResidentSessionFile(
+						command.sessionPath,
+						[...this.sessions.values()].map((state) => ({
+							activeSessionId: state.activeSessionId,
+							sessionFile: state.runtime.session.sessionFile,
+						})),
+					)
+				) {
 					throw new Error("Cannot delete the currently active session");
 				}
 				const result = await this.deleteSavedSessionFile(command.sessionPath, {
@@ -6507,10 +6516,10 @@ export class AgentDaemon {
 	}
 
 	private findActiveSessionByFile(sessionPath: string): ActiveSessionState | undefined {
-		const resolvedSessionPath = resolve(sessionPath);
+		const resolvedSessionPath = canonicalSessionPath(sessionPath);
 		for (const state of this.sessions.values()) {
 			const sessionFile = state.runtime.session.sessionFile;
-			if (sessionFile && resolve(sessionFile) === resolvedSessionPath) {
+			if (sessionFile && canonicalSessionPath(sessionFile) === resolvedSessionPath) {
 				return state;
 			}
 		}

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -7,6 +7,7 @@ import type { AgentSessionRuntimeMetadata } from "../../core/agent-session-runti
 import type { AgentSessionRuntimeDiagnostic } from "../../core/agent-session-services.js";
 import { type AgentCronJob, isHeartbeatCronJob } from "../../core/cron-jobs.js";
 import type { SessionActionSnapshot } from "../../core/session-action-store.js";
+import { canonicalSessionPath } from "../../core/session-lease.js";
 import type { AgentTaskState, SessionInfo } from "../../core/session-manager.js";
 import type { AgentConnectionRlmChildAgentSnapshot } from "../agent-connection/types.js";
 import type { ActiveSessionState } from "./active-session-state.js";
@@ -105,6 +106,24 @@ export function classifySessionRosterStatus(summary: SessionSummary): SessionRos
 	if (!summary.activeSessionId) return "inactive";
 	if (summary.hasActiveHeartbeat || summary.activity === "working" || isSessionSummaryBusy(summary)) return "running";
 	return "idle";
+}
+
+/**
+ * True when a daemon still hosts this session file as a live session.
+ * Passive/no-`activeSessionId` summaries (passivated RLM children listed by a
+ * parent worker) do not occupy the file. Descriptor/`createCommand` paths are
+ * not occupancy; callers must pass live summaries only.
+ */
+export function hasLiveResidentSessionFile(
+	sessionPath: string,
+	summaries: Iterable<Pick<SessionSummary, "activeSessionId" | "sessionFile">>,
+): boolean {
+	const target = canonicalSessionPath(sessionPath);
+	for (const summary of summaries) {
+		if (!summary.activeSessionId || !summary.sessionFile) continue;
+		if (canonicalSessionPath(summary.sessionFile) === target) return true;
+	}
+	return false;
 }
 
 export function isSessionSummaryBusy(summary: SessionSummary): boolean {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -3796,10 +3796,26 @@ export class DaemonSupervisor {
 	}
 
 	private sessionFileIsLiveResident(sessionFile: string): boolean {
-		return hasLiveResidentSessionFile(
-			sessionFile,
-			[...this.workers.values()].flatMap((worker) => [...worker.summaries.values()]),
-		);
+		if (
+			hasLiveResidentSessionFile(
+				sessionFile,
+				[...this.workers.values()].flatMap((worker) => [...worker.summaries.values()]),
+			)
+		) {
+			return true;
+		}
+		const target = canonicalSessionPath(sessionFile);
+		if (this.openingWorkers.has(target)) return true;
+		for (const worker of this.workers.values()) {
+			if (worker.descriptor.lifecycle !== "starting" && worker.descriptor.lifecycle !== "recovering") {
+				continue;
+			}
+			const configured = [worker.descriptor.sessionFile, worker.descriptor.createCommand.sessionPath];
+			if (configured.some((path) => path !== undefined && canonicalSessionPath(path) === target)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private findWorkerBySessionFile(sessionFile: string): ResidentWorker | undefined {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -101,6 +101,7 @@ import { getDaemonRuntimeIdentity } from "./daemon-runtime-identity.js";
 import { matchesSessionIdSuffix } from "./daemon-session-id.js";
 import {
 	classifySessionRosterStatus,
+	hasLiveResidentSessionFile,
 	isSessionSummaryBusy,
 	type SessionSummary,
 	summaryForInactiveSession,
@@ -2110,8 +2111,7 @@ export class DaemonSupervisor {
 			}
 			case "delete_saved_session":
 				if (!command.activeSessionId) {
-					const active = this.findWorkerBySessionFile(command.sessionPath);
-					if (active) {
+					if (this.sessionFileIsLiveResident(command.sessionPath)) {
 						throw new Error("Cannot delete the currently active session");
 					}
 					const result = await this.catalog.delete(command.sessionPath);
@@ -3793,6 +3793,13 @@ export class DaemonSupervisor {
 				matchesSessionIdSuffix(activeSessionId, selector) || matchesSessionIdSuffix(summary.sessionId, selector)
 			);
 		});
+	}
+
+	private sessionFileIsLiveResident(sessionFile: string): boolean {
+		return hasLiveResidentSessionFile(
+			sessionFile,
+			[...this.workers.values()].flatMap((worker) => [...worker.summaries.values()]),
+		);
 	}
 
 	private findWorkerBySessionFile(sessionFile: string): ResidentWorker | undefined {

--- a/packages/coding-agent/test/agents-view-mode.test.ts
+++ b/packages/coding-agent/test/agents-view-mode.test.ts
@@ -12,7 +12,11 @@ import {
 	createInitialAgentsViewPersistentState,
 	runAgentsViewMode,
 } from "../src/modes/agents-view/agents-view-mode.js";
-import { type AgentsViewRow, resolveAgentsViewLeftResult } from "../src/modes/agents-view/agents-view-state.js";
+import {
+	type AgentsViewRow,
+	getAgentsViewSummaryIdentity,
+	resolveAgentsViewLeftResult,
+} from "../src/modes/agents-view/agents-view-state.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 import type { InteractiveModeUiServices } from "../src/modes/interactive/interactive-mode-services.js";
 import { stopThemeWatcher } from "../src/modes/interactive/theme/theme.js";
@@ -81,6 +85,35 @@ function invoke(method: string, self: object, ...args: unknown[]): unknown {
 	return member.call(self, ...args);
 }
 
+function deleteSelectedHarness(overrides: Record<string, unknown>): Record<string, unknown> {
+	const self: Record<string, unknown> = {
+		pendingDeleteAgent: undefined,
+		pendingKillSubagent: undefined,
+		deleteConfirmExpiresAt: 0,
+		deleteConfirmTimer: undefined,
+		lastListedSummaries: [],
+		scopeRootSummary: undefined,
+		scopeKey: undefined,
+		ui: { requestRender: vi.fn() },
+		setStatusMessage: vi.fn(),
+		refreshSessions: vi.fn(async () => true),
+		refreshSavedSessions: vi.fn(async () => true),
+		getSavedSessionCatalogContext: () => ({ cwd: "/tmp" }),
+		...overrides,
+	};
+	self.handleKillSubagentSelected = (row: unknown) => invoke("handleKillSubagentSelected", self, row);
+	self.findSubagentRootRow = (row: unknown) => invoke("findSubagentRootRow", self, row);
+	self.resolveInactiveRlmChildDeleteTarget = (row: unknown) =>
+		invoke("resolveInactiveRlmChildDeleteTarget", self, row);
+	self.resolveRlmSubagentParentActiveSessionId = (row: unknown) =>
+		invoke("resolveRlmSubagentParentActiveSessionId", self, row);
+	self.isDeleteConfirmationVisible = () => invoke("isDeleteConfirmationVisible", self);
+	self.showDeleteConfirmation = () => invoke("showDeleteConfirmation", self);
+	self.clearDeleteConfirmation = (options: unknown) => invoke("clearDeleteConfirmation", self, options);
+	self.killSubagent = (pending: unknown, row: unknown) => invoke("killSubagent", self, pending, row);
+	return self;
+}
+
 const settingsManager = {
 	getTheme: () => "dark",
 	getShowHardwareCursor: () => false,
@@ -123,59 +156,35 @@ describe("AgentsViewMode", () => {
 			data: command.type === "cancel_rlm_child" ? { cancelled: false } : { deleted: true },
 		}));
 		const client = { request, supportsServerCapability: vi.fn(() => true) };
-		const self = {
-			rows: [
-				{
-					kind: "subagent",
-					section: "running",
-					summary: child,
-					selectable: true,
-					identity: "child-row",
-					parentIdentity: "root-row",
-				},
-				{
-					kind: "agent",
-					section: "idle",
-					summary: summary({ id: "root-active", activeSessionId: "root-active", sessionId: "root-session" }),
-					selectable: true,
-					identity: "root-row",
-				},
-			],
+		const rows = [
+			{
+				kind: "subagent" as const,
+				section: "running" as AgentsViewRow["section"],
+				summary: child,
+				selectable: true,
+				identity: "child-row",
+				parentIdentity: "root-row",
+			},
+			{
+				kind: "agent" as const,
+				section: "idle" as AgentsViewRow["section"],
+				summary: summary({ id: "root-active", activeSessionId: "root-active", sessionId: "root-session" }),
+				selectable: true,
+				identity: "root-row",
+			},
+		];
+		const self = deleteSelectedHarness({
+			rows,
 			selectedIndex: 0,
-			pendingDeleteAgent: undefined,
-			pendingKillSubagent: undefined,
-			deleteConfirmExpiresAt: 0,
-			deleteConfirmTimer: undefined,
-			ui: { requestRender: vi.fn() },
 			requireClient: () => client,
-			setStatusMessage: vi.fn(),
-			refreshSessions: vi.fn(async () => true),
-			handleKillSubagentSelected(row: unknown) {
-				return invoke("handleKillSubagentSelected", self, row);
-			},
-			findSubagentRootRow(row: unknown) {
-				return invoke("findSubagentRootRow", self, row);
-			},
-			isDeleteConfirmationVisible() {
-				return invoke("isDeleteConfirmationVisible", self);
-			},
-			showDeleteConfirmation() {
-				return invoke("showDeleteConfirmation", self);
-			},
-			clearDeleteConfirmation(options: unknown) {
-				return invoke("clearDeleteConfirmation", self, options);
-			},
-			killSubagent(pending: unknown, row: unknown) {
-				return invoke("killSubagent", self, pending, row);
-			},
-		};
+		});
 
 		await invoke("handleDeleteSelected", self);
 		expect(request).not.toHaveBeenCalled();
 
 		// The child finishes during confirmation. The second keypress must use the
 		// current row state rather than the original running state.
-		self.rows[0]!.section = "inactive";
+		rows[0]!.section = "inactive";
 		await invoke("handleDeleteSelected", self);
 		expect(request).toHaveBeenCalledWith({
 			type: "delete_rlm_subagent",
@@ -229,6 +238,148 @@ describe("AgentsViewMode", () => {
 			render: false,
 			tone: "warning",
 		});
+	});
+
+	it("deletes a scoped Inactive RLM child agent row via delete_rlm_subagent", async () => {
+		const child = summary({
+			id: "registry-child",
+			activeSessionId: undefined,
+			sessionId: "registry-child",
+			sessionFile: "/tmp/project/registry-child.jsonl",
+			runtimeKind: "subagent",
+			parentSessionId: "root-session",
+			parentActiveSessionId: "root-active",
+			rlmChildId: "passive-child",
+			rlmDepth: 1,
+		});
+		const request = vi.fn(async (command: { type: string }) => ({
+			success: true as const,
+			data: command.type === "delete_rlm_subagent" ? { deleted: true } : { sessions: [] },
+		}));
+		const client = { request, supportsServerCapability: vi.fn(() => true) };
+		const self = deleteSelectedHarness({
+			rows: [
+				{
+					kind: "agent",
+					section: "inactive",
+					summary: child,
+					selectable: true,
+					identity: "child-row",
+					depth: 0,
+				},
+			],
+			selectedIndex: 0,
+			requireClient: () => client,
+		});
+
+		await invoke("handleDeleteSelected", self);
+		expect(request).not.toHaveBeenCalled();
+		expect(self.pendingKillSubagent).toMatchObject({
+			childId: "passive-child",
+			rootActiveSessionId: "root-active",
+		});
+
+		await invoke("handleDeleteSelected", self);
+		expect(request).toHaveBeenCalledWith({
+			type: "delete_rlm_subagent",
+			activeSessionId: "root-active",
+			childId: "passive-child",
+		});
+		expect(request).not.toHaveBeenCalledWith(expect.objectContaining({ type: "delete_saved_session" }));
+		expect(self.setStatusMessage).toHaveBeenCalledWith("Subagent deleted", { render: false });
+	});
+
+	it("resolves a scoped Inactive child parent from the live list when parentActiveSessionId is absent", async () => {
+		const child = summary({
+			id: "registry-child",
+			activeSessionId: undefined,
+			sessionId: "registry-child",
+			sessionFile: "/tmp/project/registry-child.jsonl",
+			runtimeKind: "subagent",
+			parentSessionId: "root-session",
+			rlmChildId: "passive-child",
+			rlmDepth: 1,
+		});
+		const request = vi.fn(async () => ({ success: true as const, data: { deleted: true } }));
+		const self = deleteSelectedHarness({
+			rows: [
+				{
+					kind: "agent",
+					section: "inactive",
+					summary: child,
+					selectable: true,
+					identity: "child-row",
+					depth: 0,
+				},
+			],
+			selectedIndex: 0,
+			lastListedSummaries: [
+				summary({
+					id: "root-active",
+					activeSessionId: "root-active",
+					sessionId: "root-session",
+					sessionFile: "/tmp/project/root.jsonl",
+				}),
+			],
+			requireClient: () => ({ request, supportsServerCapability: () => true }),
+		});
+
+		await invoke("handleDeleteSelected", self);
+		await invoke("handleDeleteSelected", self);
+		expect(request).toHaveBeenCalledWith({
+			type: "delete_rlm_subagent",
+			activeSessionId: "root-active",
+			childId: "passive-child",
+		});
+	});
+
+	it("deletes a saved-only Inactive agent row with saved-session delete when RLM ids are unknown", async () => {
+		const saved = summary({
+			id: "saved-child",
+			activeSessionId: undefined,
+			sessionId: "saved-child",
+			sessionFile: "/tmp/project/saved-child.jsonl",
+			runtimeKind: "subagent",
+			parentSessionPath: "/tmp/project/root.jsonl",
+			rlmDepth: 1,
+		});
+		const request = vi.fn(async (command: { type: string }) => {
+			if (command.type === "list") {
+				return { success: true as const, data: { sessions: [saved] } };
+			}
+			if (command.type === "delete_saved_session") {
+				return { success: true as const, data: { ok: true, method: "unlink" as const } };
+			}
+			throw new Error(`unexpected command ${command.type}`);
+		});
+		const self = deleteSelectedHarness({
+			rows: [
+				{
+					kind: "agent",
+					section: "inactive",
+					summary: saved,
+					selectable: true,
+					identity: "saved-row",
+					depth: 0,
+				},
+			],
+			selectedIndex: 0,
+			requireClient: () => ({ request, supportsServerCapability: () => true }),
+			refreshSavedSessions: vi.fn(async () => true),
+			getSavedSessionCatalogContext: () => ({ cwd: "/tmp/project" }),
+		});
+
+		await invoke("handleDeleteSelected", self);
+		expect(request).not.toHaveBeenCalled();
+
+		await invoke("handleDeleteSelected", self);
+		expect(request).toHaveBeenCalledWith({ type: "list" });
+		expect(request).toHaveBeenCalledWith({
+			type: "delete_saved_session",
+			sessionPath: "/tmp/project/saved-child.jsonl",
+		});
+		expect(request).not.toHaveBeenCalledWith(expect.objectContaining({ type: "delete_rlm_subagent" }));
+		expect(self.setStatusMessage).toHaveBeenCalledWith("Session deleted");
 	});
 
 	it("checks telemetry policy before replying from an opted-out agents view", async () => {
@@ -597,21 +748,22 @@ describe("AgentsViewMode", () => {
 				expect(rowsOf(self).some((row) => row.kind === "subagent-summary" && row.expanded)).toBe(true);
 			}
 			// The runtime flushes the session file; the record identity flips to file:.
-			self.lastListedSummaries = [{ ...parent, sessionFile: "/tmp/root.jsonl" }, child];
+			const persistedParent = { ...parent, sessionFile: "/tmp/root.jsonl" };
+			self.lastListedSummaries = [persistedParent, child];
 			invoke("reconcileCatalogs", self);
-			return { self, expandedSubagentParents };
+			return { self, expandedSubagentParents, persistedIdentity: getAgentsViewSummaryIdentity(persistedParent) };
 		};
 
 		const expandedView = buildView(true);
 		const expandedRows = rowsOf(expandedView.self);
 		expect(
 			expandedRows.find((row) => row.kind === "agent" && row.summary.sessionId === "root-session")?.identity,
-		).toBe("file:/tmp/root.jsonl");
+		).toBe(expandedView.persistedIdentity);
 		expect(expandedRows.some((row) => row.kind === "subagent-summary" && row.expanded)).toBe(true);
 		expect(expandedRows.some((row) => row.kind === "subagent" && row.summary.sessionId === "child-session")).toBe(
 			true,
 		);
-		expect([...expandedView.expandedSubagentParents]).toEqual(["file:/tmp/root.jsonl"]);
+		expect([...expandedView.expandedSubagentParents]).toEqual([expandedView.persistedIdentity]);
 
 		const collapsedView = buildView(false);
 		const collapsedRows = rowsOf(collapsedView.self);

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -7634,7 +7634,7 @@ describe("daemon mode helpers", () => {
 			// Jobs-store bookkeeping must not fail the deletion or skip the sweep.
 			await internals.createSubagentRuntimeHost(parentState).deleteRlmSubagentRuntime(fixture.childId);
 
-			expect(internals.cancelScheduledJobsForSessionFile).toHaveBeenCalledOnce();
+			expect(internals.cancelScheduledJobsForSessionFile).toHaveBeenCalled();
 			expect(existsSync(fixture.childArtifactDir)).toBe(false);
 			expect(existsSync(fixture.childSessionFile)).toBe(true);
 		} finally {
@@ -8703,6 +8703,93 @@ describe("daemon mode helpers", () => {
 			expect(internals.cronStore.list().find((job) => job.id === heartbeat.id)).toMatchObject({
 				status: "active",
 			});
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("deletes a saved session that is not live-resident even when a parent session is in memory", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-delete-passive-"));
+		try {
+			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir },
+				createRuntime: async () => {
+					throw new Error("unexpected runtime creation");
+				},
+			});
+			const deleteSavedSessionFile = vi.fn(async () => ({ ok: true, method: "unlink" as const }));
+			const childFile = join(tempDir, "passive-child.jsonl");
+			const parentFile = join(tempDir, "parent.jsonl");
+			const parentState = {
+				activeSessionId: "parent-active",
+				clients: new Set(),
+				pendingAttaches: 0,
+				lastEventSequence: 0,
+				runtime: {
+					metadata: { kind: "top-level", createdAt: 1 },
+					session: { sessionFile: parentFile, sessionId: "parent-session" },
+				},
+			} as unknown as ActiveSessionState;
+			const internals = daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				deleteSavedSessionFile: typeof deleteSavedSessionFile;
+				handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+			};
+			internals.deleteSavedSessionFile = deleteSavedSessionFile;
+			internals.sessions.set(parentState.activeSessionId, parentState);
+
+			const response = await internals.handleCommand(makeClient("client-1", parentState.activeSessionId), {
+				id: "command-1",
+				type: "delete_saved_session",
+				sessionPath: childFile,
+			});
+
+			expect(response).toMatchObject({ data: { ok: true, method: "unlink" } });
+			expect(deleteSavedSessionFile).toHaveBeenCalledWith(childFile, {
+				afterFileRemoved: expect.any(Function),
+			});
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("refuses to delete a session file that is still live-resident", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-delete-live-"));
+		try {
+			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir },
+				createRuntime: async () => {
+					throw new Error("unexpected runtime creation");
+				},
+			});
+			const deleteSavedSessionFile = vi.fn(async () => ({ ok: true, method: "unlink" as const }));
+			const sessionFile = join(tempDir, "live.jsonl");
+			const state = {
+				activeSessionId: "live-active",
+				clients: new Set(),
+				pendingAttaches: 0,
+				lastEventSequence: 0,
+				runtime: {
+					metadata: { kind: "top-level", createdAt: 1 },
+					session: { sessionFile, sessionId: "live-session" },
+				},
+			} as unknown as ActiveSessionState;
+			const internals = daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				deleteSavedSessionFile: typeof deleteSavedSessionFile;
+				handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+			};
+			internals.deleteSavedSessionFile = deleteSavedSessionFile;
+			internals.sessions.set(state.activeSessionId, state);
+
+			await expect(
+				internals.handleCommand(makeClient("client-1", state.activeSessionId), {
+					id: "command-1",
+					type: "delete_saved_session",
+					sessionPath: sessionFile,
+				}),
+			).rejects.toThrow("Cannot delete the currently active session");
+			expect(deleteSavedSessionFile).not.toHaveBeenCalled();
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/daemon-session-list.test.ts
+++ b/packages/coding-agent/test/daemon-session-list.test.ts
@@ -7,6 +7,7 @@ import type { ActiveSessionState, DaemonSocketClient } from "../src/modes/daemon
 import {
 	buildRlmChildSnapshots,
 	buildSessionList,
+	hasLiveResidentSessionFile,
 	resolveAttachModelFallbackMessage,
 	type SessionSummary,
 	summaryForActiveSession,
@@ -677,6 +678,31 @@ describe("resolveAttachModelFallbackMessage", () => {
 
 	it("falls back to the attaching process's snapshot when the session has no model", () => {
 		expect(resolveAttachModelFallbackMessage(makeSummary({}), startupMessage)).toBe(startupMessage);
+	});
+});
+
+describe("hasLiveResidentSessionFile", () => {
+	it("treats a live summary with activeSessionId as occupying the file", () => {
+		expect(
+			hasLiveResidentSessionFile("/tmp/live.jsonl", [{ activeSessionId: "live-1", sessionFile: "/tmp/live.jsonl" }]),
+		).toBe(true);
+	});
+
+	it("does not treat a passive/no-activeSessionId summary as occupying the file", () => {
+		expect(
+			hasLiveResidentSessionFile("/tmp/child.jsonl", [
+				{ activeSessionId: "parent-1", sessionFile: "/tmp/parent.jsonl" },
+				{ activeSessionId: undefined, sessionFile: "/tmp/child.jsonl" },
+			]),
+		).toBe(false);
+	});
+
+	it("ignores summaries that name a different live file", () => {
+		expect(
+			hasLiveResidentSessionFile("/tmp/stale.jsonl", [
+				{ activeSessionId: "other-live", sessionFile: "/tmp/other.jsonl" },
+			]),
+		).toBe(false);
 	});
 });
 

--- a/packages/coding-agent/test/daemon-supervisor-delete-saved-session.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-delete-saved-session.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
+import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
+
+function makeSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
+	return {
+		id: "session-1",
+		lifecycle: "live",
+		activity: "idle",
+		isSessionActive: false,
+		sessionId: "session-1",
+		cwd: "/tmp/project",
+		isStreaming: false,
+		isCompacting: false,
+		attachedClients: 0,
+		messageCount: 1,
+		sessionActions: { queuedCount: 0, steering: [], followUps: [] },
+		...overrides,
+	};
+}
+
+function makeWorker(workerId: string, summaries: SessionSummary[], sessionFile?: string) {
+	return {
+		descriptor: {
+			workerId,
+			sessionFile: sessionFile ?? summaries.find((summary) => summary.activeSessionId)?.sessionFile,
+			createCommand: {
+				type: "create" as const,
+				sessionPath: sessionFile ?? summaries.find((summary) => summary.activeSessionId)?.sessionFile,
+			},
+		},
+		summaries: new Map(summaries.map((summary) => [summary.activeSessionId ?? summary.id, summary])),
+	};
+}
+
+function supervisorWithWorkers(workers: Array<ReturnType<typeof makeWorker>>, catalogDelete: ReturnType<typeof vi.fn>) {
+	return Object.assign(Object.create(DaemonSupervisor.prototype), {
+		workers: new Map(workers.map((worker) => [worker.descriptor.workerId, worker])),
+		catalog: { delete: catalogDelete },
+	}) as {
+		handleCommand(
+			client: object,
+			command: { id?: string; type: "delete_saved_session"; sessionPath: string; activeSessionId?: string },
+		): Promise<{ success: boolean; data?: unknown; error?: string }>;
+		sessionFileIsLiveResident(sessionFile: string): boolean;
+	};
+}
+
+describe("daemon supervisor delete_saved_session occupancy", () => {
+	it("deletes a file listed only as a passive/no-activeSessionId worker summary", async () => {
+		const childPath = "/tmp/project/registry-child.jsonl";
+		const catalogDelete = vi.fn(async () => ({ ok: true, method: "unlink" as const }));
+		const supervisor = supervisorWithWorkers(
+			[
+				makeWorker("parent", [
+					makeSummary({
+						id: "root-active",
+						activeSessionId: "root-active",
+						sessionId: "root-session",
+						sessionFile: "/tmp/project/root.jsonl",
+					}),
+					makeSummary({
+						id: "registry-child",
+						activeSessionId: undefined,
+						sessionId: "registry-child",
+						sessionFile: childPath,
+						runtimeKind: "subagent",
+						parentSessionId: "root-session",
+						rlmChildId: "passive-child",
+					}),
+				]),
+			],
+			catalogDelete,
+		);
+
+		expect(supervisor.sessionFileIsLiveResident(childPath)).toBe(false);
+		const response = await supervisor.handleCommand(
+			{},
+			{ id: "del-1", type: "delete_saved_session", sessionPath: childPath },
+		);
+
+		expect(response).toMatchObject({ success: true, data: { ok: true, method: "unlink" } });
+		expect(catalogDelete).toHaveBeenCalledWith(childPath);
+	});
+
+	it("deletes a file named only by a stale worker descriptor or createCommand path", async () => {
+		const stalePath = "/tmp/project/stale.jsonl";
+		const catalogDelete = vi.fn(async () => ({ ok: true, method: "unlink" as const }));
+		const supervisor = supervisorWithWorkers(
+			[
+				makeWorker(
+					"stale-descriptor",
+					[
+						makeSummary({
+							id: "other-live",
+							activeSessionId: "other-live",
+							sessionId: "other-session",
+							sessionFile: "/tmp/project/other.jsonl",
+						}),
+					],
+					stalePath,
+				),
+			],
+			catalogDelete,
+		);
+
+		expect(supervisor.sessionFileIsLiveResident(stalePath)).toBe(false);
+		const response = await supervisor.handleCommand(
+			{},
+			{ id: "del-2", type: "delete_saved_session", sessionPath: stalePath },
+		);
+
+		expect(response).toMatchObject({ success: true, data: { ok: true } });
+		expect(catalogDelete).toHaveBeenCalledWith(stalePath);
+	});
+
+	it("refuses to delete a file a worker still hosts as a live session", async () => {
+		const livePath = "/tmp/project/live.jsonl";
+		const catalogDelete = vi.fn(async () => ({ ok: true, method: "unlink" as const }));
+		const supervisor = supervisorWithWorkers(
+			[
+				makeWorker("live", [
+					makeSummary({
+						id: "live-active",
+						activeSessionId: "live-active",
+						sessionId: "live-session",
+						sessionFile: livePath,
+					}),
+				]),
+			],
+			catalogDelete,
+		);
+
+		expect(supervisor.sessionFileIsLiveResident(livePath)).toBe(true);
+		await expect(
+			supervisor.handleCommand({}, { id: "del-3", type: "delete_saved_session", sessionPath: livePath }),
+		).rejects.toThrow("Cannot delete the currently active session");
+		expect(catalogDelete).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/daemon-supervisor-delete-saved-session.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-delete-saved-session.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
+import { canonicalSessionPath } from "../src/core/session-lease.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
+import type { DaemonWorkerLifecycle } from "../src/modes/daemon/daemon-worker-protocol.js";
 
 function makeSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
 	return {
@@ -19,23 +21,35 @@ function makeSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
 	};
 }
 
-function makeWorker(workerId: string, summaries: SessionSummary[], sessionFile?: string) {
+function makeWorker(
+	workerId: string,
+	summaries: SessionSummary[],
+	sessionFile?: string,
+	lifecycle: DaemonWorkerLifecycle = "ready",
+) {
+	const configuredPath = sessionFile ?? summaries.find((summary) => summary.activeSessionId)?.sessionFile;
 	return {
 		descriptor: {
 			workerId,
-			sessionFile: sessionFile ?? summaries.find((summary) => summary.activeSessionId)?.sessionFile,
+			lifecycle,
+			sessionFile: configuredPath,
 			createCommand: {
 				type: "create" as const,
-				sessionPath: sessionFile ?? summaries.find((summary) => summary.activeSessionId)?.sessionFile,
+				sessionPath: configuredPath,
 			},
 		},
 		summaries: new Map(summaries.map((summary) => [summary.activeSessionId ?? summary.id, summary])),
 	};
 }
 
-function supervisorWithWorkers(workers: Array<ReturnType<typeof makeWorker>>, catalogDelete: ReturnType<typeof vi.fn>) {
+function supervisorWithWorkers(
+	workers: Array<ReturnType<typeof makeWorker>>,
+	catalogDelete: ReturnType<typeof vi.fn>,
+	openingWorkers: Map<string, Promise<unknown>> = new Map(),
+) {
 	return Object.assign(Object.create(DaemonSupervisor.prototype), {
 		workers: new Map(workers.map((worker) => [worker.descriptor.workerId, worker])),
+		openingWorkers,
 		catalog: { delete: catalogDelete },
 	}) as {
 		handleCommand(
@@ -112,6 +126,49 @@ describe("daemon supervisor delete_saved_session occupancy", () => {
 
 		expect(response).toMatchObject({ success: true, data: { ok: true } });
 		expect(catalogDelete).toHaveBeenCalledWith(stalePath);
+	});
+
+	it("refuses to delete a file a starting worker is opening before summaries exist", async () => {
+		const openingPath = "/tmp/project/opening.jsonl";
+		const catalogDelete = vi.fn(async () => ({ ok: true, method: "unlink" as const }));
+		const supervisor = supervisorWithWorkers([makeWorker("starting", [], openingPath, "starting")], catalogDelete);
+
+		expect(supervisor.sessionFileIsLiveResident(openingPath)).toBe(true);
+		await expect(
+			supervisor.handleCommand({}, { id: "del-4", type: "delete_saved_session", sessionPath: openingPath }),
+		).rejects.toThrow("Cannot delete the currently active session");
+		expect(catalogDelete).not.toHaveBeenCalled();
+	});
+
+	it("refuses to delete a file a recovering worker is registered for before summaries exist", async () => {
+		const recoveringPath = "/tmp/project/recovering.jsonl";
+		const catalogDelete = vi.fn(async () => ({ ok: true, method: "unlink" as const }));
+		const supervisor = supervisorWithWorkers(
+			[makeWorker("recovering", [], recoveringPath, "recovering")],
+			catalogDelete,
+		);
+
+		expect(supervisor.sessionFileIsLiveResident(recoveringPath)).toBe(true);
+		await expect(
+			supervisor.handleCommand({}, { id: "del-5", type: "delete_saved_session", sessionPath: recoveringPath }),
+		).rejects.toThrow("Cannot delete the currently active session");
+		expect(catalogDelete).not.toHaveBeenCalled();
+	});
+
+	it("refuses to delete a file whose create is already in-flight", async () => {
+		const openingPath = "/tmp/project/pending-open.jsonl";
+		const catalogDelete = vi.fn(async () => ({ ok: true, method: "unlink" as const }));
+		const supervisor = supervisorWithWorkers(
+			[],
+			catalogDelete,
+			new Map([[canonicalSessionPath(openingPath), Promise.resolve({})]]),
+		);
+
+		expect(supervisor.sessionFileIsLiveResident(openingPath)).toBe(true);
+		await expect(
+			supervisor.handleCommand({}, { id: "del-6", type: "delete_saved_session", sessionPath: openingPath }),
+		).rejects.toThrow("Cannot delete the currently active session");
+		expect(catalogDelete).not.toHaveBeenCalled();
 	});
 
 	it("refuses to delete a file a worker still hosts as a live session", async () => {


### PR DESCRIPTION
## Summary

Deleting an **Inactive** agents-view row that was not the live chat session failed with `Cannot delete the currently active session`. That error is occupancy, not "the row you have selected / the session you are chatting in": the supervisor treated a session file as active whenever any resident worker listed it.

Parent workers list passivated RLM children as summaries **without** `activeSessionId`. `findWorkerBySessionFile` also matched stale `descriptor.sessionFile` / `createCommand.sessionPath`. Scoped/orphaned children render as depth-0 `kind: "agent"` Inactive rows, so confirm-delete used `delete_saved_session` instead of `delete_rlm_subagent`.

## Fix

- Occupancy for saved-session delete is live residency only: a worker/daemon summary with `activeSessionId` for that file. Passive summaries and stale descriptor paths no longer block delete.
- Live-resident files still cannot be removed with saved-session delete.
- Inactive RLM children with parent + `rlmChildId` go through `delete_rlm_subagent` so ledger/registry state is tombstoned. Saved-only rows without those ids use saved-session delete once occupancy is honest.

## Test plan

- `packages/coding-agent`: `npx tsx ../../node_modules/vitest/dist/cli.js --run test/daemon-session-list.test.ts test/daemon-supervisor-delete-saved-session.test.ts test/agents-view-mode.test.ts test/daemon-mode.test.ts`
- `npm run check` from repo root

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows deleting Inactive agents-view rows that are not live-resident sessions. Previously any worker summary naming the file blocked with “Cannot delete the currently active session”; now only live-resident files and sessions in start/recover flight block delete, preventing race deletes.

- Gate `delete_saved_session` by live occupancy: `hasLiveResidentSessionFile` considers only summaries with `activeSessionId`. The supervisor also treats starting/recovering workers and in-flight opens as occupying their configured `sessionFile`. Ready-worker stale descriptor/createCommand paths no longer block delete.
- Route scoped Inactive RLM children with `parentActiveSessionId` and `rlmChildId` through `delete_rlm_subagent`; otherwise use `delete_saved_session`. Canonicalize session paths/identities and resolve parent `activeSessionId` from the tree, scope, or last live list.
- Live-resident files still cannot be removed.

<sup>Written for commit 82b18cbfdeb6bbd3b11e149a628d196be8067112. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LuciferMornens/oneharness/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

