### PR TITLE
fix(coding-agent): fail-open silent IPython cells and stuck RLM children

### DIFF
--- a/packages/coding-agent/.changes/inactivity-fail-open.md
+++ b/packages/coding-agent/.changes/inactivity-fail-open.md
@@ -1,0 +1,1 @@
+- Added `inactivityTimeoutMs` (default 15 minutes) so a silent IPython cell or stuck RLM child fail-opens with a timeout result instead of hanging indefinitely.

--- a/packages/coding-agent/docs/rlm.md
+++ b/packages/coding-agent/docs/rlm.md
@@ -50,6 +50,8 @@ npm run check
 
 Each `%%bash` cell is a temporary subshell, while Python state and `%cd` changes persist in the kernel. Prime Agent extensions may intentionally add custom tools, but the built-in RLM design does not require a separate model tool for every capability.
 
+A cell or child tool wait that produces no stream, tool, or bash activity for `inactivityTimeoutMs` (default 15 minutes) is aborted and the parent receives a timeout/cancelled result. Output resets the timer. Set `inactivityTimeoutMs` to `0` to disable. LLM turns with no in-flight tools are not stalled.
+
 ### 2. Subagents are native RLM calls
 
 The callable `rlm` object is preloaded in the kernel. Spawn a child with a direct call:

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -209,6 +209,7 @@ Normally the package manager's global modules location is queried using `root -g
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `sessionDir` | string | - | Directory where session files are stored. Accepts absolute or relative paths, plus `~`. |
+| `inactivityTimeoutMs` | number | `900000` (15 minutes) | Fail-open if an IPython cell or RLM child tool/bash wait produces no activity for this long. Stream output, tool updates, and bash output reset the timer. LLM turns with no in-flight tools are not stalled. `0` disables. |
 
 ```json
 { "sessionDir": ".prime/agent/sessions" }

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -379,6 +379,17 @@ export type AgentSessionEvent =
 
 export type AgentSessionEventListener = (event: AgentSessionEvent) => void;
 
+function isInactivityProgressEvent(event: AgentSessionEvent): boolean {
+	return (
+		event.type === "tool_execution_start" ||
+		event.type === "tool_execution_update" ||
+		event.type === "tool_execution_end" ||
+		event.type === "bash_start" ||
+		event.type === "bash_output" ||
+		event.type === "bash_end"
+	);
+}
+
 type UserBashEndDetails = {
 	exitCode: number | undefined;
 	cancelled: boolean;
@@ -8985,6 +8996,7 @@ export class AgentSession {
 					provisioner: this._ipythonKernelProvisioner,
 					commandPrefix: this.settingsManager.getShellCommandPrefix(),
 					shellPath: this.settingsManager.getShellPath(),
+					stallTimeoutMs: () => this.settingsManager.getInactivityTimeoutMs(),
 					onLateSentAgentMessage: (toolCallId, message) =>
 						this._recordLateIpythonSentAgentMessage(toolCallId, message),
 				},
@@ -10023,10 +10035,21 @@ export class AgentSession {
 		);
 	}
 
+	private _hasStallableInactivityWork(): boolean {
+		return this.isBashRunning || this.unfinishedActionCount > 0;
+	}
+
+	private _failOpenInactivity(): void {
+		if (this.isBashRunning) this.abortBash();
+		this.agent.abort();
+	}
+
 	private async _waitWhileRlmChildLive(child: AgentSession, run: RlmChildRun): Promise<void> {
 		if (run.status === "cancelled" || this._disposed || this._disposing || !child.hasLiveRlmSessionWork()) {
 			return;
 		}
+		const timeoutMs = this.settingsManager.getInactivityTimeoutMs();
+		let lastProgress = Date.now();
 		await new Promise<void>((resolve) => {
 			let settled = false;
 			const finish = () => {
@@ -10041,9 +10064,18 @@ export class AgentSession {
 			const check = () => {
 				if (run.status === "cancelled" || this._disposed || this._disposing || !child.hasLiveRlmSessionWork()) {
 					finish();
+					return;
+				}
+				if (timeoutMs > 0 && child._hasStallableInactivityWork() && Date.now() - lastProgress >= timeoutMs) {
+					this._cancelRlmChildRun(
+						run,
+						`RLM child stalled for ${Math.max(1, Math.round(timeoutMs / 1000))}s with no activity`,
+					);
+					finish();
 				}
 			};
-			const unsubscribe = child.subscribe(() => {
+			const unsubscribe = child.subscribe((event) => {
+				if (isInactivityProgressEvent(event)) lastProgress = Date.now();
 				check();
 			});
 			const timer = setInterval(check, 20);
@@ -10081,6 +10113,11 @@ export class AgentSession {
 		if (externalSignal?.aborted) cancellation.abort();
 		else externalSignal?.addEventListener("abort", cancelFromParent, { once: true });
 		this._rlmQuiescenceWaitAborts.add(cancellation);
+		const timeoutMs = this.settingsManager.getInactivityTimeoutMs();
+		let lastProgress = Date.now();
+		const unsubscribeProgress = this.subscribe((event) => {
+			if (isInactivityProgressEvent(event)) lastProgress = Date.now();
+		});
 		let rejectCancelled = (_error: Error) => {};
 		const cancelled = new Promise<never>((_resolve, reject) => {
 			rejectCancelled = reject;
@@ -10097,6 +10134,9 @@ export class AgentSession {
 				// intentionally ignores. Yield a macrotask while such work is active so
 				// recursive parent/child barriers cannot form a microtask busy-loop.
 				if (this.isSessionActive || this._hasDeferredRlmTerminalNotices()) {
+					if (timeoutMs > 0 && this._hasStallableInactivityWork() && Date.now() - lastProgress >= timeoutMs) {
+						this._failOpenInactivity();
+					}
 					await wait(new Promise<void>((resolve) => setTimeout(resolve, 0)));
 					continue;
 				}
@@ -10113,6 +10153,7 @@ export class AgentSession {
 				// start at the child-settlement boundary.
 			}
 		} finally {
+			unsubscribeProgress();
 			// A local descendant error must cancel sibling recursive waits owned by
 			// this barrier before their propagation listeners are removed.
 			cancellation.abort();

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -192,6 +192,12 @@ export interface ExecuteOptions {
 	maxOutputChars?: number;
 	/** Synthetic host cell (snapshot/restore/list); excluded from lastCellCode attribution. */
 	internal?: boolean;
+	/**
+	 * Abort the cell if no kernel activity arrives for this many milliseconds.
+	 * Stream, execute_result, display, and host-request comm traffic reset the timer.
+	 * 0 or omitted disables the stall watchdog.
+	 */
+	stallTimeoutMs?: number;
 }
 
 /** MIME tag the `edit` skill emits diff payloads under, via `display_data`. */
@@ -408,6 +414,7 @@ interface ActiveExecution {
 	settled: boolean;
 	resolve: (result: ExecuteResult) => void;
 	reject: (error: Error) => void;
+	bumpStall?: () => void;
 }
 
 interface Deferred<T> {
@@ -1066,10 +1073,25 @@ export class KernelManager {
 			reject: result.reject,
 		};
 		let abortTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
+		let stallTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
+		const stallTimeoutMs =
+			opts.stallTimeoutMs !== undefined && Number.isFinite(opts.stallTimeoutMs) && opts.stallTimeoutMs > 0
+				? opts.stallTimeoutMs
+				: undefined;
+		const stallController = stallTimeoutMs !== undefined ? new AbortController() : undefined;
+		const abortSources = [opts.signal, stallController?.signal].filter((signal): signal is AbortSignal =>
+			Boolean(signal),
+		);
 		const clearAbortTimer = () => {
 			if (abortTimer) {
 				globalThis.clearTimeout(abortTimer);
 				abortTimer = undefined;
+			}
+		};
+		const clearStallTimer = () => {
+			if (stallTimer) {
+				globalThis.clearTimeout(stallTimer);
+				stallTimer = undefined;
 			}
 		};
 		const forceAbort = () => {
@@ -1087,12 +1109,30 @@ export class KernelManager {
 				abortTimer.unref();
 			}
 		};
+		const onAbortFromSource = () => onAbort();
+		if (stallTimeoutMs !== undefined && stallController) {
+			execution.bumpStall = () => {
+				if (execution.settled || stallController.signal.aborted) return;
+				clearStallTimer();
+				stallTimer = globalThis.setTimeout(() => {
+					if (execution.settled || stallController.signal.aborted) return;
+					const seconds = Math.max(1, Math.round(stallTimeoutMs / 1000));
+					execution.stderr += `${execution.stderr ? "\n" : ""}IPython cell aborted after ${seconds}s with no kernel output`;
+					stallController.abort();
+				}, stallTimeoutMs);
+				stallTimer.unref?.();
+			};
+		}
 
 		try {
 			this.activeExecution = execution;
-			opts.signal?.addEventListener("abort", onAbort, { once: true });
-			if (opts.signal?.aborted) {
+			for (const source of abortSources) {
+				source.addEventListener("abort", onAbortFromSource, { once: true });
+			}
+			if (abortSources.some((source) => source.aborted)) {
 				onAbort();
+			} else {
+				execution.bumpStall?.();
 			}
 			if (!opts.internal) {
 				this.lastCellCode = code;
@@ -1113,7 +1153,11 @@ export class KernelManager {
 			return await result.promise;
 		} finally {
 			clearAbortTimer();
-			opts.signal?.removeEventListener("abort", onAbort);
+			clearStallTimer();
+			execution.bumpStall = undefined;
+			for (const source of abortSources) {
+				source.removeEventListener("abort", onAbortFromSource);
+			}
 		}
 	}
 
@@ -1227,6 +1271,9 @@ export class KernelManager {
 		}
 
 		const t = incoming.header.msg_type;
+		if (!execution.settled) {
+			execution.bumpStall?.();
+		}
 		if (execution.settled && (t === "display_data" || t === "update_display_data")) {
 			const content = incoming.content as { data?: Record<string, unknown> };
 			if (this.dispatchLateSentAgentMessage(parentMessageId, content.data?.[AGENT_MESSAGE_DISPLAY_MIME])) {
@@ -1426,6 +1473,10 @@ export class KernelManager {
 	}
 
 	private handleCommMessage(incoming: JupyterMessage): void {
+		const execution = this.activeExecution;
+		if (execution && !execution.settled) {
+			execution.bumpStall?.();
+		}
 		const msgType = incoming.header.msg_type;
 		const content = incoming.content;
 		const commId = content.comm_id;

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -7,6 +7,8 @@ import { CONFIG_DIR_NAME, getAgentDir } from "../config.js";
 
 const RECENT_MODELS_LIMIT = 20;
 export const DEFAULT_IDLE_EVICTION_MINUTES = 90;
+/** Fail-open if an IPython cell or RLM child tool wait produces no activity. 0 disables. */
+export const DEFAULT_INACTIVITY_TIMEOUT_MS = 15 * 60 * 1000;
 
 export interface CompactionSettings {
 	enabled?: boolean; // default: true
@@ -134,6 +136,13 @@ export interface Settings {
 	defaultThinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 	defaultServiceTier?: ServiceTier;
 	rlmMaxDepth?: number; // default for new sessions; unset falls through to RLM_MAX_DEPTH, then 1
+	/**
+	 * Abort a silent IPython cell or stuck RLM child tool wait after this many
+	 * milliseconds with no activity (stream, tool update, bash output, host
+	 * request). Streaming LLM turns without tools are not stalled. 0 disables.
+	 * Default: 15 minutes.
+	 */
+	inactivityTimeoutMs?: number;
 	idleEvictionMinutes?: number | "off"; // global daemon policy; default: 90
 	transport?: TransportSetting; // default: "auto"
 	steeringMode?: "all" | "one-at-a-time";
@@ -780,6 +789,13 @@ export class SettingsManager {
 		this.globalSettings.rlmMaxDepth = maxDepth;
 		this.markModified("rlmMaxDepth");
 		this.save();
+	}
+
+	getInactivityTimeoutMs(): number {
+		const value = this.settings.inactivityTimeoutMs;
+		if (value === 0) return 0;
+		if (typeof value === "number" && Number.isFinite(value) && value > 0) return value;
+		return DEFAULT_INACTIVITY_TIMEOUT_MS;
 	}
 
 	getIdleEvictionMinutes(): number | "off" {

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -193,6 +193,12 @@ function createAbortError(): Error {
 	return new Error("IPython execution aborted");
 }
 
+function resolveStallTimeoutMs(value: number | (() => number) | undefined): number | undefined {
+	const resolved = typeof value === "function" ? value() : value;
+	if (resolved === undefined || !Number.isFinite(resolved) || resolved <= 0) return undefined;
+	return resolved;
+}
+
 function raceWithAbort<T>(promise: Promise<T>, signal: AbortSignal | undefined, onAbort?: () => void): Promise<T> {
 	if (!signal) {
 		return promise;
@@ -323,6 +329,12 @@ export interface IpythonToolOptions {
 	onLateSentAgentMessage?: (toolCallId: string, message: KernelSentAgentMessage) => void;
 	/** Shared provisioner owning the kernel lifecycle. When provided, the remaining options are ignored. */
 	provisioner?: IpythonKernelProvisioner;
+	/**
+	 * Abort a user cell that produces no kernel output for this many milliseconds.
+	 * A function is resolved at each execute so session settings can change live.
+	 * 0 or omitted disables the stall watchdog.
+	 */
+	stallTimeoutMs?: number | (() => number);
 }
 
 function quoteScriptMagicArgument(value: string): string {
@@ -640,6 +652,7 @@ async function executeWithBusyKernelChoice(
 	onWorkingMessage: (message?: string) => void,
 	onLateSentAgentMessage: ((toolCallId: string, message: KernelSentAgentMessage) => void) | undefined,
 	ctx: ExtensionContext | undefined,
+	stallTimeoutMs: number | undefined,
 ): Promise<{ result: ExecuteResult; kernelRestarted: boolean }> {
 	let kernelRestarted = false;
 	while (true) {
@@ -648,6 +661,7 @@ async function executeWithBusyKernelChoice(
 			return {
 				result: await m.execute(code, {
 					signal,
+					stallTimeoutMs,
 					onStream,
 					onLateSentAgentMessage: onLateSentAgentMessage
 						? (message) => onLateSentAgentMessage(toolCallId, message)
@@ -734,6 +748,7 @@ export function createIpythonToolDefinition(
 					setToolWorkingMessage,
 					options?.onLateSentAgentMessage,
 					ctx,
+					resolveStallTimeoutMs(options?.stallTimeoutMs),
 				);
 
 				let text = r.stdout;

--- a/packages/coding-agent/test/kernel-abort.test.ts
+++ b/packages/coding-agent/test/kernel-abort.test.ts
@@ -318,6 +318,144 @@ describe("KernelManager abort handling", () => {
 		manager.disposeSync();
 	});
 
+	it("aborts a silent user cell after stallTimeoutMs with no kernel output", async () => {
+		vi.useFakeTimers();
+		const manager = new KernelManager({ cwd: process.cwd() });
+		const shellSend = vi.fn(async (_frames: Buffer[]) => {});
+		const controlSend = vi.fn(async (_frames: Buffer[]) => {});
+		Object.assign(
+			manager as unknown as {
+				state: "running";
+				connection: {
+					ip: "127.0.0.1";
+					transport: "tcp";
+					shell_port: number;
+					iopub_port: number;
+					stdin_port: number;
+					control_port: number;
+					hb_port: number;
+					signature_scheme: "hmac-sha256";
+					key: string;
+					kernel_name: string;
+				};
+				shell: { send: (frames: Buffer[]) => Promise<void>; close: () => void };
+				control: { send: (frames: Buffer[]) => Promise<void>; close: () => void };
+				start: () => Promise<void>;
+			},
+			{
+				state: "running",
+				connection: {
+					ip: "127.0.0.1",
+					transport: "tcp",
+					shell_port: 1,
+					iopub_port: 2,
+					stdin_port: 3,
+					control_port: 4,
+					hb_port: 5,
+					signature_scheme: "hmac-sha256",
+					key: "test-key",
+					kernel_name: "python3",
+				},
+				shell: { send: shellSend, close: vi.fn() },
+				control: { send: controlSend, close: vi.fn() },
+				start: async () => {},
+			},
+		);
+
+		const executePromise = manager.execute("while True: pass", { stallTimeoutMs: 100 });
+		await waitForCalls(shellSend, 1);
+		await vi.advanceTimersByTimeAsync(99);
+		await Promise.resolve();
+		const stillPending = await Promise.race([
+			executePromise.then(() => "settled" as const),
+			Promise.resolve("pending" as const),
+		]);
+		expect(stillPending).toBe("pending");
+
+		await vi.advanceTimersByTimeAsync(1 + 1000);
+		await expect(executePromise).resolves.toMatchObject({ status: "aborted" });
+		const result = await executePromise;
+		expect(result.stderr).toContain("IPython cell aborted after 1s with no kernel output");
+		expect(controlSend).toHaveBeenCalled();
+		manager.disposeSync();
+	});
+
+	it("resets the cell stall timer on kernel stream output", async () => {
+		vi.useFakeTimers();
+		const manager = new KernelManager({ cwd: process.cwd() });
+		const shellSend = vi.fn(async (_frames: Buffer[]) => {});
+		Object.assign(
+			manager as unknown as {
+				state: "running";
+				connection: {
+					ip: "127.0.0.1";
+					transport: "tcp";
+					shell_port: number;
+					iopub_port: number;
+					stdin_port: number;
+					control_port: number;
+					hb_port: number;
+					signature_scheme: "hmac-sha256";
+					key: string;
+					kernel_name: string;
+				};
+				shell: { send: (frames: Buffer[]) => Promise<void>; close: () => void };
+				control: { send: (frames: Buffer[]) => Promise<void>; close: () => void };
+				start: () => Promise<void>;
+			},
+			{
+				state: "running",
+				connection: {
+					ip: "127.0.0.1",
+					transport: "tcp",
+					shell_port: 1,
+					iopub_port: 2,
+					stdin_port: 3,
+					control_port: 4,
+					hb_port: 5,
+					signature_scheme: "hmac-sha256",
+					key: "test-key",
+					kernel_name: "python3",
+				},
+				shell: { send: shellSend, close: vi.fn() },
+				control: { send: vi.fn(async () => {}), close: vi.fn() },
+				start: async () => {},
+			},
+		);
+
+		const executePromise = manager.execute("print('tick')", { stallTimeoutMs: 500 });
+		await waitForCalls(shellSend, 1);
+		const internals = manager as unknown as {
+			activeExecution?: { requestMsgId: string };
+			handleExecutionMessage: (incoming: {
+				header: { msg_type: string };
+				parent_header: Record<string, unknown>;
+				metadata: Record<string, unknown>;
+				content: Record<string, unknown>;
+			}) => void;
+		};
+		const requestMsgId = internals.activeExecution?.requestMsgId;
+		expect(requestMsgId).toBeDefined();
+
+		await vi.advanceTimersByTimeAsync(400);
+		internals.handleExecutionMessage({
+			header: { msg_type: "stream" },
+			parent_header: { msg_id: requestMsgId },
+			metadata: {},
+			content: { name: "stdout", text: "tick\n" },
+		});
+		await vi.advanceTimersByTimeAsync(400);
+		const stillPending = await Promise.race([
+			executePromise.then(() => "settled" as const),
+			Promise.resolve("pending" as const),
+		]);
+		expect(stillPending).toBe("pending");
+
+		await vi.advanceTimersByTimeAsync(100 + 1000);
+		await expect(executePromise).resolves.toMatchObject({ status: "aborted" });
+		manager.disposeSync();
+	});
+
 	it("starts the snapshot timeout after earlier kernel work finishes", async () => {
 		vi.useFakeTimers();
 		const manager = new KernelManager({

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -479,6 +479,22 @@ describe("SettingsManager", () => {
 			});
 		});
 	});
+	describe("inactivity fail-open", () => {
+		it("defaults to 15 minutes and treats 0 as disabled", () => {
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getInactivityTimeoutMs()).toBe(15 * 60 * 1000);
+
+			manager.applyOverrides({ inactivityTimeoutMs: 0 });
+			expect(manager.getInactivityTimeoutMs()).toBe(0);
+		});
+
+		it("reads a positive override", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ inactivityTimeoutMs: 30_000 }));
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getInactivityTimeoutMs()).toBe(30_000);
+		});
+	});
+
 	describe("idle worker eviction", () => {
 		it("defaults to 90 minutes and treats none as off", () => {
 			const manager = SettingsManager.create(projectDir, agentDir);

--- a/packages/coding-agent/test/subagent-timeout-hang.test.ts
+++ b/packages/coding-agent/test/subagent-timeout-hang.test.ts
@@ -19,7 +19,7 @@ import { KernelManager } from "../src/core/kernel/index.js";
 import { convertToLlm } from "../src/core/messages.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
 import { SessionManager } from "../src/core/session-manager.js";
-import { SettingsManager } from "../src/core/settings-manager.js";
+import { type Settings, SettingsManager } from "../src/core/settings-manager.js";
 import { createLocalBashOperations } from "../src/core/tools/bash.js";
 import { createIpythonTool, IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
 import { waitForHeadlessCompletion } from "../src/modes/headless-completion.js";
@@ -159,6 +159,7 @@ function createSession(
 		maxDepth?: number;
 		rlmSessionDir?: string;
 		streamFn?: StreamFn;
+		settingsOverrides?: Partial<Settings>;
 		subagentRuntimeHost?: ConstructorParameters<typeof AgentSession>[0]["subagentRuntimeHost"];
 	} = {},
 ): AgentSession {
@@ -170,10 +171,12 @@ function createSession(
 		initialState: { model, systemPrompt: "", tools: [], thinkingLevel: "off" },
 		streamFn: options.streamFn ?? ((_model, context) => streamAnswer(`child answer: ${userText(context)}`)),
 	});
+	const settingsManager = SettingsManager.create(tempDir, tempDir);
+	if (options.settingsOverrides) settingsManager.applyOverrides(options.settingsOverrides);
 	return new AgentSession({
 		agent,
 		sessionManager: SessionManager.create(tempDir, join(tempDir, "sessions")),
-		settingsManager: SettingsManager.create(tempDir, tempDir),
+		settingsManager,
 		cwd: tempDir,
 		modelRegistry: ModelRegistry.create(authStorage, join(tempDir, "models.json")),
 		resourceLoader: createTestResourceLoader(),
@@ -235,7 +238,9 @@ describe("subagent timeout hang", () => {
 
 		it("ipython tool execute does not wrap the kernel cell in a timeout", async () => {
 			const provisioner = new IpythonKernelProvisioner(process.cwd());
-			const execute = vi.fn((_code: string, _opts?: { signal?: AbortSignal }) => new Promise<never>(() => {}));
+			const execute = vi.fn(
+				(_code: string, _opts?: { signal?: AbortSignal; stallTimeoutMs?: number }) => new Promise<never>(() => {}),
+			);
 			vi.spyOn(provisioner, "ensure").mockResolvedValue({ execute } as unknown as KernelManager);
 			const tool = createIpythonTool(process.cwd(), { provisioner });
 			const signal = new AbortController().signal;
@@ -247,8 +252,19 @@ describe("subagent timeout hang", () => {
 			const executeOpts = execute.mock.calls[0]?.[1];
 			expect(executeOpts).toMatchObject({ signal });
 			expect(executeOpts).not.toHaveProperty("executionTimeoutMs");
+			expect(executeOpts?.stallTimeoutMs).toBeUndefined();
 			expect(await outcomeWithin(toolPromise, 200)).toBe("pending");
 			expect(state.settled).toBe(false);
+		});
+
+		it("ipython tool forwards stallTimeoutMs to kernel execute", async () => {
+			const provisioner = new IpythonKernelProvisioner(process.cwd());
+			const execute = vi.fn((_code: string, _opts?: { stallTimeoutMs?: number }) => new Promise<never>(() => {}));
+			vi.spyOn(provisioner, "ensure").mockResolvedValue({ execute } as unknown as KernelManager);
+			const tool = createIpythonTool(process.cwd(), { provisioner, stallTimeoutMs: () => 12_000 });
+			void tool.execute("tool-stall", { code: "pass" });
+			await vi.waitFor(() => expect(execute).toHaveBeenCalled());
+			expect(execute.mock.calls[0]?.[1]?.stallTimeoutMs).toBe(12_000);
 		});
 	});
 
@@ -454,6 +470,91 @@ describe("subagent timeout hang", () => {
 			await bash;
 			await expect(quiescence).resolves.toBeUndefined();
 			await expect(headless).resolves.toBeDefined();
+		});
+
+		it("fail-opens a silent RLM child tool wait and delivers a parent-visible cancelled result", async () => {
+			const childDir = join(tempDir, "child-fail-open");
+			mkdirSync(childDir, { recursive: true });
+			const settingsOverrides = { inactivityTimeoutMs: 100 };
+			let childStarted = false;
+			let releaseChild = () => {};
+			const childGate = new Promise<void>((resolve) => {
+				releaseChild = resolve;
+			});
+			const child = createSession(childDir, {
+				depth: 1,
+				rlmSessionDir: join(childDir, "rlm"),
+				settingsOverrides,
+				streamFn: () => {
+					childStarted = true;
+					const stream = createAssistantMessageEventStream();
+					void childGate.then(() => {
+						stream.push({
+							type: "done",
+							reason: "stop",
+							message: {
+								role: "assistant",
+								content: [{ type: "text", text: "first turn" }],
+								api: model.api,
+								provider: model.provider,
+								model: model.id,
+								usage: usage(),
+								stopReason: "stop",
+								timestamp: Date.now(),
+							},
+						});
+					});
+					return stream;
+				},
+			});
+			sessions.push(child);
+
+			const rootDir = join(tempDir, "root-fail-open");
+			mkdirSync(rootDir, { recursive: true });
+			const root = createSession(rootDir, {
+				maxDepth: 1,
+				rlmSessionDir: join(rootDir, "rlm"),
+				settingsOverrides,
+				subagentRuntimeHost: {
+					createRlmSubagentRuntime: async () => ({ session: child }),
+					deleteRlmSubagentRuntime: async () => {},
+				},
+			});
+			sessions.push(root);
+
+			await root.runRlmChild("do work that times out", { name: "fail-open-worker" });
+			await vi.waitFor(() => expect(childStarted).toBe(true));
+
+			const bash = child.executeBash("silent-hang", undefined, {
+				operations: {
+					exec: async (_command, _cwd, { signal }) => {
+						await new Promise<void>((_resolve, reject) => {
+							if (signal?.aborted) {
+								reject(new Error("aborted"));
+								return;
+							}
+							signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+						});
+						return { exitCode: 0 };
+					},
+				},
+			});
+			await vi.waitFor(() => expect(child.isBashRunning).toBe(true));
+			releaseChild();
+			await vi.waitFor(() => expect(child.getLastAssistantText()).toBe("first turn"));
+
+			await vi.waitFor(() => {
+				expect(
+					root.messages.some(
+						(message) =>
+							message.role === "custom" &&
+							typeof message.content === "string" &&
+							message.content.includes("stalled"),
+					),
+				).toBe(true);
+			});
+			await expect(bash).resolves.toMatchObject({ cancelled: true });
+			await expect(root.waitForRlmQuiescence()).resolves.toBeUndefined();
 		});
 	});
 });

--- a/packages/coding-agent/test/subagent-timeout-hang.test.ts
+++ b/packages/coding-agent/test/subagent-timeout-hang.test.ts
@@ -1,0 +1,459 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { Agent, type AgentMessage, type StreamFn } from "@earendil-works/pi-agent-core";
+import {
+	type Context,
+	createAssistantMessageEventStream,
+	getModel,
+	type TextContent,
+	type Usage,
+} from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSession } from "../src/core/agent-session.js";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { execCommand } from "../src/core/exec.js";
+import { KernelManager } from "../src/core/kernel/index.js";
+import { convertToLlm } from "../src/core/messages.js";
+import { ModelRegistry } from "../src/core/model-registry.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+import { createLocalBashOperations } from "../src/core/tools/bash.js";
+import { createIpythonTool, IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
+import { waitForHeadlessCompletion } from "../src/modes/headless-completion.js";
+import * as shellModule from "../src/utils/shell.js";
+import { createTestResourceLoader } from "./utilities.js";
+
+const model = getModel("anthropic", "claude-sonnet-4-5")!;
+const WINDOWS_COMMAND_TERMINATION_SETTLE_MS = 31_000;
+const USER_CELL_NO_DEADLINE_MS = 6_000;
+
+function usage(): Usage {
+	return {
+		input: 7,
+		output: 3,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 10,
+		cost: { input: 7, output: 3, cacheRead: 0, cacheWrite: 0, total: 10 },
+	};
+}
+
+function streamAnswer(text: string): ReturnType<typeof createAssistantMessageEventStream> {
+	const stream = createAssistantMessageEventStream();
+	queueMicrotask(() => {
+		stream.push({
+			type: "done",
+			reason: "stop",
+			message: {
+				role: "assistant",
+				content: [{ type: "text", text }],
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				usage: usage(),
+				stopReason: "stop",
+				timestamp: Date.now(),
+			},
+		});
+	});
+	return stream;
+}
+
+function userText(context: Context): string {
+	const lastMessage = context.messages[context.messages.length - 1] as AgentMessage | undefined;
+	if (!lastMessage || (lastMessage.role !== "user" && lastMessage.role !== "custom")) return "";
+	if (typeof lastMessage.content === "string") return lastMessage.content;
+	return lastMessage.content
+		.filter((block): block is TextContent => block.type === "text")
+		.map((block) => block.text)
+		.join("\n");
+}
+
+interface InspectableRlmRun {
+	settled: boolean;
+	status: string;
+	settlement?: { promise: Promise<void> };
+}
+
+interface InspectableRlmSession {
+	_activeRlmChildRuns: Map<string, InspectableRlmRun>;
+	_unsettledRlmChildRuns: Set<InspectableRlmRun>;
+}
+
+function hangState<T>(promise: Promise<T>): { settled: boolean } {
+	const state = { settled: false };
+	void promise.then(
+		() => {
+			state.settled = true;
+		},
+		() => {
+			state.settled = true;
+		},
+	);
+	return state;
+}
+
+async function outcomeWithin<T>(promise: Promise<T>, ms: number): Promise<"settled" | "pending"> {
+	const state = hangState(promise);
+	await Promise.race([promise.catch(() => undefined), sleep(ms)]);
+	return state.settled ? "settled" : "pending";
+}
+
+function killPid(pid: number): void {
+	try {
+		if (process.platform === "win32") {
+			execFileSync("taskkill", ["/F", "/T", "/PID", String(pid)], { stdio: "ignore" });
+		} else {
+			process.kill(pid, "SIGKILL");
+		}
+	} catch {
+		// Already gone.
+	}
+}
+
+async function waitForFile(path: string): Promise<void> {
+	const deadline = Date.now() + 10_000;
+	while (!existsSync(path)) {
+		if (Date.now() >= deadline) throw new Error(`Child did not write ${path}`);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+	}
+}
+
+function readPid(path: string): number {
+	const pid = Number.parseInt(readFileSync(path, "utf8").trim(), 10);
+	if (!Number.isInteger(pid) || pid <= 0) throw new Error(`Invalid pid in ${path}`);
+	return pid;
+}
+
+function stubRunningKernel(manager: KernelManager): { shellSend: ReturnType<typeof vi.fn> } {
+	const shellSend = vi.fn(async (_frames: Buffer[]) => {});
+	Object.assign(manager as unknown as Record<string, unknown>, {
+		state: "running",
+		connection: {
+			ip: "127.0.0.1",
+			transport: "tcp",
+			shell_port: 1,
+			iopub_port: 2,
+			stdin_port: 3,
+			control_port: 4,
+			hb_port: 5,
+			signature_scheme: "hmac-sha256",
+			key: "test-key",
+			kernel_name: "python3",
+		},
+		shell: { send: shellSend, close: vi.fn() },
+		control: { send: vi.fn(async () => {}), close: vi.fn() },
+		kernel: { exitCode: null, signalCode: null, kill: vi.fn(() => true) },
+		start: async () => {},
+	});
+	return { shellSend };
+}
+
+function createSession(
+	tempDir: string,
+	options: {
+		depth?: number;
+		maxDepth?: number;
+		rlmSessionDir?: string;
+		streamFn?: StreamFn;
+		subagentRuntimeHost?: ConstructorParameters<typeof AgentSession>[0]["subagentRuntimeHost"];
+	} = {},
+): AgentSession {
+	const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+	authStorage.setRuntimeApiKey("anthropic", "test-key");
+	const agent = new Agent({
+		convertToLlm,
+		getApiKey: () => "test-key",
+		initialState: { model, systemPrompt: "", tools: [], thinkingLevel: "off" },
+		streamFn: options.streamFn ?? ((_model, context) => streamAnswer(`child answer: ${userText(context)}`)),
+	});
+	return new AgentSession({
+		agent,
+		sessionManager: SessionManager.create(tempDir, join(tempDir, "sessions")),
+		settingsManager: SettingsManager.create(tempDir, tempDir),
+		cwd: tempDir,
+		modelRegistry: ModelRegistry.create(authStorage, join(tempDir, "models.json")),
+		resourceLoader: createTestResourceLoader(),
+		subagentRuntimeHost: options.subagentRuntimeHost,
+		rlmDepth: options.depth,
+		rlmMaxDepth: options.maxDepth,
+		rlmSessionDir: options.rlmSessionDir,
+	});
+}
+
+describe("subagent timeout hang", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	describe("IPython user-cell execute", () => {
+		it("does not fail-open a blocking user cell with no abort signal", async () => {
+			vi.useFakeTimers();
+			const manager = new KernelManager({ cwd: process.cwd() });
+			const { shellSend } = stubRunningKernel(manager);
+			const executePromise = manager.execute("while True: pass");
+			const state = hangState(executePromise);
+
+			await vi.waitFor(() => expect(shellSend).toHaveBeenCalled());
+			await vi.advanceTimersByTimeAsync(USER_CELL_NO_DEADLINE_MS);
+			await Promise.resolve();
+
+			expect(state.settled).toBe(false);
+			manager.disposeSync();
+		});
+
+		it("does not fail-open while a host_request handler never replies", async () => {
+			vi.useFakeTimers();
+			const hangingHandler = vi.fn(async () => new Promise<Record<string, unknown>>(() => {}));
+			const manager = new KernelManager({
+				cwd: process.cwd(),
+				hostHandlers: { "rlm.run": hangingHandler },
+			});
+			const { shellSend } = stubRunningKernel(manager);
+
+			(
+				manager as unknown as { startHostRequestFromComm(commId: string, data: unknown): void }
+			).startHostRequestFromComm("comm-hang", { type: "rlm.run", prompt: "stuck" });
+			expect(hangingHandler).toHaveBeenCalledTimes(1);
+
+			const executePromise = manager.execute("await rlm.host_request('rlm.run', {'prompt': 'stuck'})");
+			const executeState = hangState(executePromise);
+			const hostState = hangState(hangingHandler.mock.results[0]?.value as Promise<unknown>);
+
+			await vi.waitFor(() => expect(shellSend).toHaveBeenCalled());
+			await vi.advanceTimersByTimeAsync(USER_CELL_NO_DEADLINE_MS);
+			await Promise.resolve();
+
+			expect(hostState.settled).toBe(false);
+			expect(executeState.settled).toBe(false);
+			manager.disposeSync();
+		});
+
+		it("ipython tool execute does not wrap the kernel cell in a timeout", async () => {
+			const provisioner = new IpythonKernelProvisioner(process.cwd());
+			const execute = vi.fn((_code: string, _opts?: { signal?: AbortSignal }) => new Promise<never>(() => {}));
+			vi.spyOn(provisioner, "ensure").mockResolvedValue({ execute } as unknown as KernelManager);
+			const tool = createIpythonTool(process.cwd(), { provisioner });
+			const signal = new AbortController().signal;
+
+			const toolPromise = tool.execute("tool-hang", { code: "import time; time.sleep(10 ** 9)" }, signal);
+			const state = hangState(toolPromise);
+			await vi.waitFor(() => expect(execute).toHaveBeenCalled());
+
+			const executeOpts = execute.mock.calls[0]?.[1];
+			expect(executeOpts).toMatchObject({ signal });
+			expect(executeOpts).not.toHaveProperty("executionTimeoutMs");
+			expect(await outcomeWithin(toolPromise, 200)).toBe("pending");
+			expect(state.settled).toBe(false);
+		});
+	});
+
+	describe("bash / exec timeout", () => {
+		let testDir: string;
+		const livePids: number[] = [];
+
+		beforeEach(() => {
+			testDir = join(tmpdir(), `subagent-timeout-hang-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+			mkdirSync(testDir, { recursive: true });
+			livePids.length = 0;
+		});
+
+		afterEach(() => {
+			for (const pid of livePids) killPid(pid);
+			rmSync(testDir, { recursive: true, force: true });
+		});
+
+		it("bash timeout returns a tool error when the child can be killed", async () => {
+			const bash = createLocalBashOperations();
+			const result = bash.exec(
+				`${JSON.stringify(process.execPath)} -e ${JSON.stringify("setTimeout(()=>{}, 30000)")}`,
+				testDir,
+				{
+					onData: () => {},
+					timeout: 1,
+				},
+			);
+			await expect(result).rejects.toThrow(/timeout:1/);
+		});
+
+		it("exec timeout against a SIGTERM-insensitive child still settles when tree kill works", async () => {
+			const readyFile = join(testDir, "exec-ready");
+			const resultPromise = execCommand(
+				process.execPath,
+				[
+					"-e",
+					`const { writeFileSync } = require("node:fs"); process.on("SIGTERM", () => {}); writeFileSync(process.argv[1], String(process.pid)); setInterval(() => {}, 1000);`,
+					readyFile,
+				],
+				testDir,
+				{ timeout: 1000 },
+			);
+			await waitForFile(readyFile);
+			livePids.push(readPid(readyFile));
+			const result = await resultPromise;
+			expect(result.killed || result.code !== 0).toBe(true);
+		});
+
+		it("has no default bash timeout, so an untimed command stays pending", async () => {
+			const controller = new AbortController();
+			const bash = createLocalBashOperations();
+			const execPromise = bash.exec(
+				`${JSON.stringify(process.execPath)} -e ${JSON.stringify("setTimeout(()=>{}, 30000)")}`,
+				testDir,
+				{ onData: () => {}, signal: controller.signal },
+			);
+			const state = hangState(execPromise);
+			expect(await outcomeWithin(execPromise, 250)).toBe("pending");
+			expect(state.settled).toBe(false);
+			controller.abort();
+			await execPromise.catch(() => undefined);
+		});
+
+		it("when tree kill never completes, only Windows fail-opens the bash timeout", async () => {
+			vi.spyOn(shellModule, "killProcessTreeByIdentity").mockImplementation(() => new Promise<boolean>(() => {}));
+			vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval"] });
+
+			const readyFile = join(testDir, "kill-hang-ready");
+			const execPromise = execCommand(
+				process.execPath,
+				[
+					"-e",
+					`const { writeFileSync } = require("node:fs"); writeFileSync(process.argv[1], String(process.pid)); setInterval(() => {}, 1000);`,
+					readyFile,
+				],
+				testDir,
+				{ timeout: 50 },
+			);
+			await waitForFile(readyFile);
+			livePids.push(readPid(readyFile));
+			const state = hangState(execPromise);
+
+			await vi.advanceTimersByTimeAsync(50);
+			await Promise.resolve();
+			expect(state.settled).toBe(false);
+
+			await vi.advanceTimersByTimeAsync(WINDOWS_COMMAND_TERMINATION_SETTLE_MS);
+			await Promise.resolve();
+			await Promise.resolve();
+
+			if (process.platform === "win32") {
+				expect(state.settled).toBe(true);
+				const result = await execPromise;
+				expect(result.code).toBe(1);
+			} else {
+				expect(state.settled).toBe(false);
+			}
+		});
+	});
+
+	describe("RLM child live / quiescence waiters", () => {
+		let tempDir: string;
+		const sessions: AgentSession[] = [];
+
+		beforeEach(() => {
+			tempDir = join(tmpdir(), `subagent-rlm-hang-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+			mkdirSync(tempDir, { recursive: true });
+			sessions.length = 0;
+		});
+
+		afterEach(() => {
+			for (const session of sessions) session.dispose();
+			rmSync(tempDir, { recursive: true, force: true });
+		});
+
+		it("does not fail-open after an inner tool stays live: run never settles and parent gets no terminal result", async () => {
+			const childDir = join(tempDir, "child");
+			mkdirSync(childDir, { recursive: true });
+			let childStarted = false;
+			let releaseChild = () => {};
+			const childGate = new Promise<void>((resolve) => {
+				releaseChild = resolve;
+			});
+			const child = createSession(childDir, {
+				depth: 1,
+				rlmSessionDir: join(childDir, "rlm"),
+				streamFn: () => {
+					childStarted = true;
+					const stream = createAssistantMessageEventStream();
+					void childGate.then(() => {
+						stream.push({
+							type: "done",
+							reason: "stop",
+							message: {
+								role: "assistant",
+								content: [{ type: "text", text: "first turn" }],
+								api: model.api,
+								provider: model.provider,
+								model: model.id,
+								usage: usage(),
+								stopReason: "stop",
+								timestamp: Date.now(),
+							},
+						});
+					});
+					return stream;
+				},
+			});
+			sessions.push(child);
+
+			const rootDir = join(tempDir, "root");
+			mkdirSync(rootDir, { recursive: true });
+			const root = createSession(rootDir, {
+				maxDepth: 1,
+				rlmSessionDir: join(rootDir, "rlm"),
+				subagentRuntimeHost: {
+					createRlmSubagentRuntime: async () => ({ session: child }),
+					deleteRlmSubagentRuntime: async () => {},
+				},
+			});
+			sessions.push(root);
+
+			const spawned = await root.runRlmChild("do work that times out", { name: "stuck-worker" });
+			await vi.waitFor(() => expect(childStarted).toBe(true));
+
+			let releaseBash = () => {};
+			const bashGate = new Promise<void>((resolve) => {
+				releaseBash = resolve;
+			});
+			const bash = child.executeBash("inner-timeout-hang", undefined, {
+				operations: {
+					exec: async () => {
+						await bashGate;
+						return { exitCode: 0 };
+					},
+				},
+			});
+			await vi.waitFor(() => expect(child.hasLiveRlmSessionWork()).toBe(true));
+			releaseChild();
+			await vi.waitFor(() => expect(child.getLastAssistantText()).toBe("first turn"));
+
+			const internals = root as unknown as InspectableRlmSession;
+			const run = internals._activeRlmChildRuns.get(spawned.rlm_child_id);
+			expect(run).toBeDefined();
+			expect(run?.status).toBe("running");
+			expect(run?.settled).toBe(false);
+			expect(root.getRlmChildRunStatus(spawned.rlm_child_id)).toBe("running");
+			expect(
+				root.messages.filter(
+					(message) => message.role === "custom" && message.customType === "rlm_child_terminal_notice",
+				),
+			).toHaveLength(0);
+
+			const quiescence = root.waitForRlmQuiescence();
+			const headless = waitForHeadlessCompletion(root, { waitForRlmQuiescence: true });
+			expect(await outcomeWithin(quiescence, 400)).toBe("pending");
+			expect(await outcomeWithin(headless, 200)).toBe("pending");
+			expect(run?.settled).toBe(false);
+			expect(internals._unsettledRlmChildRuns.has(run!)).toBe(true);
+
+			releaseBash();
+			await bash;
+			await expect(quiescence).resolves.toBeUndefined();
+			await expect(headless).resolves.toBeDefined();
+		});
+	});
+});

--- a/prime-agent-runtime/test/test_host_request.py
+++ b/prime-agent-runtime/test/test_host_request.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+import unittest
+from unittest.mock import patch
+
+
+rlm_module = importlib.import_module("rlm")
+
+
+class SilentComm:
+    def __init__(self, *args, **kwargs):
+        self._on_msg = None
+
+    def on_msg(self, callback):
+        self._on_msg = callback
+
+    def open(self, data=None):
+        return None
+
+    def close(self):
+        return None
+
+
+class HostRequestTimeoutTest(unittest.TestCase):
+    def test_host_request_has_no_fail_open_when_comm_never_replies(self) -> None:
+        async def run() -> None:
+            with (
+                patch.object(rlm_module, "Comm", SilentComm),
+                patch.object(rlm_module, "_install_control_comm_handlers"),
+            ):
+                with self.assertRaises(TimeoutError):
+                    await asyncio.wait_for(rlm_module.host_request("rlm.run", {"prompt": "stuck"}), 0.2)
+
+        asyncio.run(run())


### PR DESCRIPTION
## Summary

Headless/RLM subagents could hang for hours with no parent-visible result: user-cell IPython `execute()` never installed a fail-open deadline, `host_request` awaited an unbounded comm future, and `_waitWhileRlmChildLive` / `waitForRlmQuiescence` then waited forever.

This is a progress-aware fail-open, not a short hard timeout.

- A silent IPython cell or stuck RLM child tool/bash wait aborts after `inactivityTimeoutMs` (default 15 minutes) with no activity.
- Stream output, tool updates, and bash output reset the timer.
- LLM turns with no in-flight tools are not stalled (including long thinking).
- The parent gets a cancelled/timeout result instead of hanging indefinitely.
- Set `inactivityTimeoutMs` to `0` to disable.

## Test plan

- [x] `test/kernel-abort.test.ts` — stall abort + timer reset on stream
- [x] `test/subagent-timeout-hang.test.ts` — default 15m does not kill short work; configured short inactivity fail-opens with a parent-visible cancelled result
- [x] `test/settings-manager.test.ts` — default / `0` / override
- [x] `npm run check`
