### PR TITLE
feat(ai): add abliteration.ai provider with Large V2

### DIFF
--- a/packages/ai/.changes/abliteration-provider.md
+++ b/packages/ai/.changes/abliteration-provider.md
@@ -1,0 +1,1 @@
+- Added abliteration.ai provider (`abliteration`, `https://api.abliteration.ai/v1`) with `abliterated-model-large-v2` (1M context, `low` / `high` / `max` effort), `abliterated-model-large` (1M context, `high` / `max` effort), and `abliterated-model` (262K context, text+image) over the OpenAI Responses API via `ABLITERATION_API_KEY`.

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -68,6 +68,7 @@ Unified LLM API with automatic model discovery, provider configuration, token an
 - **OpenAI Codex** (ChatGPT Plus/Pro subscription, requires OAuth, see below)
 - **DeepSeek**
 - **Anthropic**
+- **abliteration.ai** (OpenAI Responses-compatible API)
 - **audn.ai** (OpenAI-compatible API)
 - **Google**
 - **Vertex AI** (Gemini via Vertex AI)
@@ -1097,6 +1098,7 @@ In Node.js environments, you can set environment variables to avoid passing API 
 | Prime Inference | `PRIME_API_KEY` |
 | Azure OpenAI | `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_BASE_URL` (e.g. `https://{resource}.openai.azure.com`) or `AZURE_OPENAI_RESOURCE_NAME`. Supports `*.openai.azure.com` and `*.cognitiveservices.azure.com`; root endpoints auto-normalize to `/openai/v1`. Optional: `AZURE_OPENAI_API_VERSION` (default `v1`), `AZURE_OPENAI_DEPLOYMENT_NAME_MAP`. |
 | Anthropic | `ANTHROPIC_API_KEY` or `ANTHROPIC_OAUTH_TOKEN` |
+| abliteration.ai | `ABLITERATION_API_KEY` |
 | audn.ai | `AUDN_API_KEY` |
 | DeepSeek | `DEEPSEEK_API_KEY` |
 | Google | `GEMINI_API_KEY` |
@@ -1285,6 +1287,8 @@ const response = await complete(model, {
 **OpenAI Codex**: Requires a ChatGPT Plus or Pro subscription. Provides access to GPT-5.x Codex models with extended context windows and reasoning capabilities. The library automatically handles session-based prompt caching when `sessionId` is provided in stream options. You can set `transport` in stream options to `"sse"`, `"websocket"`, or `"auto"` for Codex Responses transport selection. When using WebSocket with a `sessionId`, connections are reused per session and expire after 5 minutes of inactivity.
 
 **Prime Inference**: Uses the OpenAI-compatible API at `https://api.pinference.ai/api/v1`. Set `PRIME_API_KEY` or pass an API key explicitly.
+
+**abliteration.ai**: Uses the OpenAI Responses-compatible API at `https://api.abliteration.ai/v1`. Set `ABLITERATION_API_KEY` or pass an API key explicitly. Keys start with `ak_`. The catalog includes `abliterated-model-large-v2` (1M context, text-only, GLM-5.3, native `low` / `high` / `max` reasoning effort via `reasoning.effort`, default `max`), `abliterated-model-large` (1M context, text-only, GLM-5.2, native `high` / `max`), and `abliterated-model` (262K context, text+image, `none`–`xhigh`). All models reason by default and return the trace as a `reasoning` item.
 
 **audn.ai**: Uses the OpenAI-compatible API at `https://platform.audn.ai/api/v1`. Set `AUDN_API_KEY` or pass an API key explicitly. Keys start with `sk_live_`. The catalog includes Necromicon (`necromicon`, 1M context, Kimi K3 `low` / `high` / `max` reasoning effort via `reasoning_effort`, trace in `reasoning_content`), Bartzabel (`bartzabel`, 262K context, Qwen3.8 chain that always thinks server-side and returns the trace in `reasoning_content`), and Pingu Unchained 10 (`pingu-unchained-10`, the function-calling model). Reasoning models can take tens of seconds to minutes.
 

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -2812,6 +2812,85 @@ function getAudnModels(): Model<"openai-completions">[] {
 	];
 }
 
+function getAbliterationModels(): Model<"openai-responses">[] {
+	const baseUrl = "https://api.abliteration.ai/v1";
+	return [
+		{
+			id: "abliterated-model",
+			name: "Abliterated Model",
+			api: "openai-responses",
+			provider: "abliteration",
+			baseUrl,
+			reasoning: true,
+			reasoningCapabilities: {
+				control: "effort",
+				levels: {
+					off: "none",
+					minimal: "minimal",
+					low: "low",
+					medium: "medium",
+					high: "high",
+					xhigh: "xhigh",
+					max: null,
+				},
+			},
+			input: ["text", "image"],
+			cost: { input: 3, output: 3, cacheRead: 0.3, cacheWrite: 0 },
+			contextWindow: 262144,
+			maxTokens: 262134,
+		},
+		{
+			id: "abliterated-model-large-v2",
+			name: "Abliterated Model Large V2",
+			api: "openai-responses",
+			provider: "abliteration",
+			baseUrl,
+			reasoning: true,
+			reasoningCapabilities: {
+				control: "effort",
+				levels: {
+					off: "none",
+					minimal: "low",
+					low: "low",
+					medium: "high",
+					high: "high",
+					xhigh: "max",
+					max: "max",
+				},
+			},
+			input: ["text"],
+			cost: { input: 5, output: 5, cacheRead: 0.5, cacheWrite: 0 },
+			contextWindow: 1000000,
+			maxTokens: 999990,
+			featured: true,
+		},
+		{
+			id: "abliterated-model-large",
+			name: "Abliterated Model Large",
+			api: "openai-responses",
+			provider: "abliteration",
+			baseUrl,
+			reasoning: true,
+			reasoningCapabilities: {
+				control: "effort",
+				levels: {
+					off: "none",
+					minimal: "high",
+					low: "high",
+					medium: "high",
+					high: "high",
+					xhigh: "max",
+					max: "max",
+				},
+			},
+			input: ["text"],
+			cost: { input: 5, output: 5, cacheRead: 0.5, cacheWrite: 0 },
+			contextWindow: 1000000,
+			maxTokens: 999990,
+		},
+	];
+}
+
 function getOrcaRouterAutoModel(): Model<"openai-completions"> {
 	return {
 		id: "orcarouter/auto",
@@ -2837,7 +2916,12 @@ function mergeCatalogModels(allModels: Model<any>[], extra: Model<any>[]): void 
 }
 
 function mergeStaticCatalogModels(allModels: Model<any>[]): void {
-	mergeCatalogModels(allModels, [...getGrokSubscriptionModels(), ...getAudnModels(), getOrcaRouterAutoModel()]);
+	mergeCatalogModels(allModels, [
+		...getGrokSubscriptionModels(),
+		...getAudnModels(),
+		...getAbliterationModels(),
+		getOrcaRouterAutoModel(),
+	]);
 }
 
 async function generateModels() {
@@ -3447,6 +3531,7 @@ async function generateModels() {
 	// xAI Grok subscription models (OAuth via the Grok CLI proxy)
 	allModels.push(...getGrokSubscriptionModels());
 	allModels.push(...getAudnModels());
+	allModels.push(...getAbliterationModels());
 
 	// Add missing Grok models
 	if (!allModels.some(m => m.provider === "xai" && m.id === "grok-code-fast-1")) {

--- a/packages/ai/src/env-api-keys.ts
+++ b/packages/ai/src/env-api-keys.ts
@@ -106,6 +106,7 @@ function getApiKeyEnvVars(provider: string): readonly string[] | undefined {
 	const envMap: Record<string, string> = {
 		openai: "OPENAI_API_KEY",
 		"azure-openai-responses": "AZURE_OPENAI_API_KEY",
+		abliteration: "ABLITERATION_API_KEY",
 		audn: "AUDN_API_KEY",
 		"prime-inference": "PRIME_API_KEY",
 		deepseek: "DEEPSEEK_API_KEY",

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -4,6 +4,66 @@
 import type { Model } from "./types.js";
 
 export const MODELS = {
+	"abliteration": {
+		"abliterated-model": {
+			id: "abliterated-model",
+			name: "Abliterated Model",
+			api: "openai-responses",
+			provider: "abliteration",
+			baseUrl: "https://api.abliteration.ai/v1",
+			reasoning: true,
+			thinkingLevelMap: {"off":"none","minimal":"minimal","low":"low","medium":"medium","high":"high","xhigh":"xhigh","max":null},
+			reasoningCapabilities: {"control":"effort","levels":{"off":"none","minimal":"minimal","low":"low","medium":"medium","high":"high","xhigh":"xhigh","max":null}},
+			input: ["text", "image"],
+			cost: {
+				input: 3,
+				output: 3,
+				cacheRead: 0.3,
+				cacheWrite: 0,
+			},
+			contextWindow: 262144,
+			maxTokens: 262134,
+		} satisfies Model<"openai-responses">,
+		"abliterated-model-large": {
+			id: "abliterated-model-large",
+			name: "Abliterated Model Large",
+			api: "openai-responses",
+			provider: "abliteration",
+			baseUrl: "https://api.abliteration.ai/v1",
+			reasoning: true,
+			thinkingLevelMap: {"off":"none","minimal":"high","low":"high","medium":"high","high":"high","xhigh":"max","max":"max"},
+			reasoningCapabilities: {"control":"effort","levels":{"off":"none","minimal":"high","low":"high","medium":"high","high":"high","xhigh":"max","max":"max"}},
+			input: ["text"],
+			cost: {
+				input: 5,
+				output: 5,
+				cacheRead: 0.5,
+				cacheWrite: 0,
+			},
+			contextWindow: 1000000,
+			maxTokens: 999990,
+		} satisfies Model<"openai-responses">,
+		"abliterated-model-large-v2": {
+			id: "abliterated-model-large-v2",
+			name: "Abliterated Model Large V2",
+			api: "openai-responses",
+			provider: "abliteration",
+			baseUrl: "https://api.abliteration.ai/v1",
+			reasoning: true,
+			thinkingLevelMap: {"off":"none","minimal":"low","low":"low","medium":"high","high":"high","xhigh":"max","max":"max"},
+			reasoningCapabilities: {"control":"effort","levels":{"off":"none","minimal":"low","low":"low","medium":"high","high":"high","xhigh":"max","max":"max"}},
+			input: ["text"],
+			cost: {
+				input: 5,
+				output: 5,
+				cacheRead: 0.5,
+				cacheWrite: 0,
+			},
+			contextWindow: 1000000,
+			maxTokens: 999990,
+			featured: true,
+		} satisfies Model<"openai-responses">,
+	},
 	"amazon-bedrock": {
 		"amazon.nova-2-lite-v1:0": {
 			id: "amazon.nova-2-lite-v1:0",

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -20,6 +20,7 @@ export type Api = KnownApi | (string & {});
 export type KnownProvider =
 	| "amazon-bedrock"
 	| "anthropic"
+	| "abliteration"
 	| "audn"
 	| "google"
 	| "google-vertex"

--- a/packages/ai/test/abliteration-models.test.ts
+++ b/packages/ai/test/abliteration-models.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { findEnvKeys, getEnvApiKey } from "../src/env-api-keys.js";
+import { clampThinkingLevel, getModel, getModels, getSupportedThinkingLevels } from "../src/models.js";
+import { streamSimple } from "../src/stream.js";
+
+const mockState = vi.hoisted(() => ({ lastParams: undefined as unknown, lastClientOptions: undefined as unknown }));
+
+vi.mock("openai", () => {
+	class FakeOpenAI {
+		responses = {
+			create: (params: unknown) => {
+				mockState.lastParams = params;
+				const stream = {
+					async *[Symbol.asyncIterator]() {},
+				};
+				const promise = Promise.resolve(stream) as Promise<typeof stream> & {
+					withResponse: () => Promise<{ data: typeof stream; response: { status: number; headers: Headers } }>;
+				};
+				promise.withResponse = async () => ({
+					data: stream,
+					response: { status: 200, headers: new Headers() },
+				});
+				return promise;
+			},
+		};
+		constructor(options: unknown) {
+			mockState.lastClientOptions = options;
+		}
+	}
+	return { default: FakeOpenAI };
+});
+
+const context = { messages: [{ role: "user" as const, content: "Hi", timestamp: 0 }] };
+
+async function responsesPayload(
+	modelId: string,
+	reasoning?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max",
+) {
+	let captured: unknown;
+	await streamSimple(getModel("abliteration", modelId as never), context, {
+		apiKey: "test",
+		...(reasoning !== undefined ? { reasoning } : {}),
+		onPayload: (value) => {
+			captured = value;
+		},
+	}).result();
+	return captured as Record<string, unknown>;
+}
+
+const originalKey = process.env.ABLITERATION_API_KEY;
+
+afterEach(() => {
+	if (originalKey === undefined) {
+		delete process.env.ABLITERATION_API_KEY;
+	} else {
+		process.env.ABLITERATION_API_KEY = originalKey;
+	}
+});
+
+describe("abliteration.ai models", () => {
+	it("registers abliterated-model-large-v2 with 1M context and low/high/max effort", () => {
+		const model = getModel("abliteration", "abliterated-model-large-v2");
+
+		expect(model).toBeDefined();
+		expect(model.api).toBe("openai-responses");
+		expect(model.provider).toBe("abliteration");
+		expect(model.baseUrl).toBe("https://api.abliteration.ai/v1");
+		expect(model.name).toBe("Abliterated Model Large V2");
+		expect(model.reasoning).toBe(true);
+		expect(model.reasoningCapabilities).toEqual({
+			control: "effort",
+			levels: {
+				off: "none",
+				minimal: "low",
+				low: "low",
+				medium: "high",
+				high: "high",
+				xhigh: "max",
+				max: "max",
+			},
+		});
+		expect(getSupportedThinkingLevels(model)).toEqual(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
+		expect(clampThinkingLevel(model, "medium")).toBe("medium");
+		expect(clampThinkingLevel(model, "minimal")).toBe("minimal");
+		expect(model.input).toEqual(["text"]);
+		expect(model.contextWindow).toBe(1000000);
+		expect(model.maxTokens).toBe(999990);
+		expect(model.featured).toBe(true);
+		expect(model.cost).toEqual({
+			input: 5,
+			output: 5,
+			cacheRead: 0.5,
+			cacheWrite: 0,
+		});
+	});
+
+	it("registers abliterated-model-large with high/max native modes", () => {
+		const model = getModel("abliteration", "abliterated-model-large");
+
+		expect(model).toBeDefined();
+		expect(model.api).toBe("openai-responses");
+		expect(model.reasoning).toBe(true);
+		expect(model.reasoningCapabilities).toEqual({
+			control: "effort",
+			levels: {
+				off: "none",
+				minimal: "high",
+				low: "high",
+				medium: "high",
+				high: "high",
+				xhigh: "max",
+				max: "max",
+			},
+		});
+		expect(getSupportedThinkingLevels(model)).toEqual(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
+		expect(model.input).toEqual(["text"]);
+		expect(model.contextWindow).toBe(1000000);
+		expect(model.maxTokens).toBe(999990);
+		expect(model.cost).toEqual({
+			input: 5,
+			output: 5,
+			cacheRead: 0.5,
+			cacheWrite: 0,
+		});
+	});
+
+	it("registers abliterated-model without max on Responses and with image input", () => {
+		const model = getModel("abliteration", "abliterated-model");
+
+		expect(model).toBeDefined();
+		expect(model.api).toBe("openai-responses");
+		expect(model.reasoning).toBe(true);
+		expect(model.reasoningCapabilities).toEqual({
+			control: "effort",
+			levels: {
+				off: "none",
+				minimal: "minimal",
+				low: "low",
+				medium: "medium",
+				high: "high",
+				xhigh: "xhigh",
+				max: null,
+			},
+		});
+		expect(getSupportedThinkingLevels(model)).toEqual(["off", "minimal", "low", "medium", "high", "xhigh"]);
+		expect(model.input).toEqual(["text", "image"]);
+		expect(model.contextWindow).toBe(262144);
+		expect(model.maxTokens).toBe(262134);
+		expect(model.cost).toEqual({
+			input: 3,
+			output: 3,
+			cacheRead: 0.3,
+			cacheWrite: 0,
+		});
+	});
+
+	it("registers the full abliteration.ai roster", () => {
+		const ids = getModels("abliteration")
+			.map((model) => model.id)
+			.sort();
+		expect(ids).toEqual(["abliterated-model", "abliterated-model-large", "abliterated-model-large-v2"]);
+	});
+
+	it("resolves ABLITERATION_API_KEY from the environment", () => {
+		process.env.ABLITERATION_API_KEY = "ak_test-abliteration-key";
+
+		expect(findEnvKeys("abliteration")).toEqual(["ABLITERATION_API_KEY"]);
+		expect(getEnvApiKey("abliteration")).toBe("ak_test-abliteration-key");
+	});
+
+	describe("responses request payloads", () => {
+		beforeEach(() => {
+			mockState.lastParams = undefined;
+			mockState.lastClientOptions = undefined;
+		});
+
+		it("targets the abliteration base URL", async () => {
+			await responsesPayload("abliterated-model-large-v2", "max");
+			expect((mockState.lastClientOptions as { baseURL?: string }).baseURL).toBe("https://api.abliteration.ai/v1");
+		});
+
+		it("sends model id with stream:true like the reference curl", async () => {
+			const params = await responsesPayload("abliterated-model-large-v2", "max");
+			expect(params).toMatchObject({
+				model: "abliterated-model-large-v2",
+				stream: true,
+				reasoning: { effort: "max" },
+			});
+		});
+
+		it("maps medium to high on large-v2 (three native modes)", async () => {
+			const params = await responsesPayload("abliterated-model-large-v2", "medium");
+			expect(params).toMatchObject({ reasoning: { effort: "high" } });
+		});
+
+		it("maps minimal to low on large-v2", async () => {
+			const params = await responsesPayload("abliterated-model-large-v2", "minimal");
+			expect(params).toMatchObject({ reasoning: { effort: "low" } });
+		});
+
+		it("sends none when reasoning is off", async () => {
+			const params = await responsesPayload("abliterated-model-large-v2", "off");
+			expect(params).toMatchObject({ reasoning: { effort: "none" } });
+		});
+
+		it("maps medium to high on large (two native modes)", async () => {
+			const params = await responsesPayload("abliterated-model-large", "medium");
+			expect(params).toMatchObject({ reasoning: { effort: "high" } });
+		});
+
+		it("sends distinct levels straight through on the base model", async () => {
+			const params = await responsesPayload("abliterated-model", "high");
+			expect(params).toMatchObject({ reasoning: { effort: "high" } });
+		});
+	});
+});

--- a/packages/ai/test/abort.test.ts
+++ b/packages/ai/test/abort.test.ts
@@ -197,6 +197,18 @@ describe("AI Providers Abort Tests", () => {
 		});
 	});
 
+	describe.skipIf(!process.env.ABLITERATION_API_KEY)("abliteration.ai Provider Abort", () => {
+		const llm = getModel("abliteration", "abliterated-model-large-v2");
+
+		it("should abort mid-stream", { retry: 3 }, async () => {
+			await testAbortSignal(llm);
+		});
+
+		it("should handle immediate abort", { retry: 3 }, async () => {
+			await testImmediateAbort(llm);
+		});
+	});
+
 	describe.skipIf(!process.env.XIAOMI_API_KEY)("Xiaomi MiMo (API billing) Provider Abort", () => {
 		const llm = getModel("xiaomi", "mimo-v2.5-pro");
 

--- a/packages/ai/test/context-overflow.test.ts
+++ b/packages/ai/test/context-overflow.test.ts
@@ -226,6 +226,17 @@ describe("Context overflow error handling", () => {
 		}, 120000);
 	});
 
+	describe.skipIf(!process.env.ABLITERATION_API_KEY)("abliteration.ai", () => {
+		it("abliterated-model-large-v2 - should detect overflow via isContextOverflow", async () => {
+			const model = getModel("abliteration", "abliterated-model-large-v2");
+			const result = await testContextOverflow(model, process.env.ABLITERATION_API_KEY!);
+			logResult(result);
+
+			expect(result.stopReason).toBe("error");
+			expect(isContextOverflow(result.response, model.contextWindow)).toBe(true);
+		}, 120000);
+	});
+
 	describe.skipIf(!process.env.GROQ_API_KEY)("Groq", () => {
 		it("llama-3.3-70b-versatile - should detect overflow via isContextOverflow", async () => {
 			const model = getModel("groq", "llama-3.3-70b-versatile");

--- a/packages/ai/test/cross-provider-handoff.test.ts
+++ b/packages/ai/test/cross-provider-handoff.test.ts
@@ -68,6 +68,8 @@ const PROVIDER_MODEL_PAIRS: ProviderModelPair[] = [
 	{ provider: "groq", model: "openai/gpt-oss-120b", label: "groq-gpt-oss-120b" },
 	{ provider: "audn", model: "pingu-unchained-10", label: "audn-pingu-unchained-10" },
 	{ provider: "audn", model: "necromicon", label: "audn-necromicon" },
+	{ provider: "abliteration", model: "abliterated-model-large-v2", label: "abliteration-large-v2" },
+	{ provider: "abliteration", model: "abliterated-model", label: "abliteration-base" },
 	{ provider: "orcarouter", model: "orcarouter/auto", label: "orcarouter-auto" },
 	{ provider: "huggingface", model: "moonshotai/Kimi-K2.5", label: "huggingface-kimi-k2.5" },
 	{ provider: "kimi-coding", model: getKimiCodingTestModel().id, label: "kimi-coding" },

--- a/packages/ai/test/empty.test.ts
+++ b/packages/ai/test/empty.test.ts
@@ -278,6 +278,26 @@ describe("AI Providers Empty Message Tests", () => {
 		});
 	});
 
+	describe.skipIf(!process.env.ABLITERATION_API_KEY)("abliteration.ai Provider Empty Messages", () => {
+		const llm = getModel("abliteration", "abliterated-model-large-v2");
+
+		it("should handle empty content array", { retry: 3, timeout: 30000 }, async () => {
+			await testEmptyMessage(llm);
+		});
+
+		it("should handle empty string content", { retry: 3, timeout: 30000 }, async () => {
+			await testEmptyStringMessage(llm);
+		});
+
+		it("should handle whitespace-only content", { retry: 3, timeout: 30000 }, async () => {
+			await testWhitespaceOnlyMessage(llm);
+		});
+
+		it("should handle empty assistant message in conversation", { retry: 3, timeout: 30000 }, async () => {
+			await testEmptyAssistantMessage(llm);
+		});
+	});
+
 	describe.skipIf(!process.env.GROQ_API_KEY)("Groq Provider Empty Messages", () => {
 		const llm = getModel("groq", "openai/gpt-oss-20b");
 

--- a/packages/ai/test/image-tool-result.test.ts
+++ b/packages/ai/test/image-tool-result.test.ts
@@ -213,6 +213,18 @@ describe("Tool Results with Images", () => {
 		});
 	});
 
+	describe.skipIf(!process.env.ABLITERATION_API_KEY)("abliteration.ai Provider (abliterated-model)", () => {
+		const llm = getModel("abliteration", "abliterated-model");
+
+		it("should handle tool result with only image", { retry: 3, timeout: 30000 }, async () => {
+			await handleToolWithImageResult(llm);
+		});
+
+		it("should handle tool result with text and image", { retry: 3, timeout: 30000 }, async () => {
+			await handleToolWithTextAndImageResult(llm);
+		});
+	});
+
 	describe.skipIf(!hasAzureOpenAICredentials())("Azure OpenAI Responses Provider (gpt-4o-mini)", () => {
 		const llm = getModel("azure-openai-responses", "gpt-4o-mini");
 		const azureDeploymentName = resolveAzureDeploymentName(llm.id);

--- a/packages/ai/test/stream.test.ts
+++ b/packages/ai/test/stream.test.ts
@@ -642,6 +642,29 @@ describe("Generate E2E Tests", () => {
 		});
 	});
 
+	describe.skipIf(!process.env.ABLITERATION_API_KEY)(
+		"abliteration.ai Provider (abliterated-model-large-v2 via OpenAI Responses)",
+		() => {
+			const llm = getModel("abliteration", "abliterated-model-large-v2");
+
+			it("should complete basic text generation", { retry: 3 }, async () => {
+				await basicTextGeneration(llm);
+			});
+
+			it("should handle tool calling", { retry: 3 }, async () => {
+				await handleToolCall(llm);
+			});
+
+			it("should handle streaming", { retry: 3 }, async () => {
+				await handleStreaming(llm);
+			});
+
+			it("should handle multi-turn with tools", { retry: 3 }, async () => {
+				await multiTurn(llm);
+			});
+		},
+	);
+
 	describe.skipIf(!hasCloudflareWorkersAICredentials())(
 		"Cloudflare Workers AI Provider (Kimi K2.6 via OpenAI Completions)",
 		() => {

--- a/packages/ai/test/stream.test.ts
+++ b/packages/ai/test/stream.test.ts
@@ -260,7 +260,10 @@ async function handleImage<TApi extends Api>(model: Model<TApi>, options?: Strea
 	}
 }
 
-async function multiTurn<TApi extends Api>(model: Model<TApi>, options?: StreamOptionsWithExtras) {
+async function multiTurn<TApi extends Api>(
+	model: Model<TApi>,
+	options?: StreamOptionsWithExtras,
+): Promise<{ hasSeenThinking: boolean; hasSeenToolCalls: boolean }> {
 	const context: Context = {
 		systemPrompt: "You are a helpful assistant that can use tools to answer questions.",
 		messages: [
@@ -332,6 +335,8 @@ async function multiTurn<TApi extends Api>(model: Model<TApi>, options?: StreamO
 	expect(allTextContent).toBeTruthy();
 	expect(allTextContent.includes("714")).toBe(true);
 	expect(allTextContent.includes("887")).toBe(true);
+
+	return { hasSeenThinking, hasSeenToolCalls };
 }
 
 describe("Generate E2E Tests", () => {
@@ -668,7 +673,9 @@ describe("Generate E2E Tests", () => {
 			});
 
 			it("should handle multi-turn with thinking and tools", { retry: 3 }, async () => {
-				await multiTurn(llm, { reasoningEffort: "high" });
+				const { hasSeenThinking, hasSeenToolCalls } = await multiTurn(llm, { reasoningEffort: "high" });
+				expect(hasSeenThinking).toBe(true);
+				expect(hasSeenToolCalls).toBe(true);
 			});
 		},
 	);

--- a/packages/ai/test/stream.test.ts
+++ b/packages/ai/test/stream.test.ts
@@ -659,8 +659,16 @@ describe("Generate E2E Tests", () => {
 				await handleStreaming(llm);
 			});
 
+			it("should handle thinking mode", { retry: 3 }, async () => {
+				await handleThinking(llm, { reasoningEffort: "high" });
+			});
+
 			it("should handle multi-turn with tools", { retry: 3 }, async () => {
 				await multiTurn(llm);
+			});
+
+			it("should handle multi-turn with thinking and tools", { retry: 3 }, async () => {
+				await multiTurn(llm, { reasoningEffort: "high" });
 			});
 		},
 	);

--- a/packages/ai/test/tokens.test.ts
+++ b/packages/ai/test/tokens.test.ts
@@ -159,6 +159,14 @@ describe("Token Statistics on Abort", () => {
 		});
 	});
 
+	describe.skipIf(!process.env.ABLITERATION_API_KEY)("abliteration.ai Provider", () => {
+		const llm = getModel("abliteration", "abliterated-model-large-v2");
+
+		it("should include token stats when aborted mid-stream", { retry: 3, timeout: 30000 }, async () => {
+			await testTokensOnAbort(llm);
+		});
+	});
+
 	describe.skipIf(!hasCloudflareWorkersAICredentials())("Cloudflare Workers AI Provider", () => {
 		const llm = getModel("cloudflare-workers-ai", "@cf/moonshotai/kimi-k2.6");
 

--- a/packages/ai/test/tool-call-without-result.test.ts
+++ b/packages/ai/test/tool-call-without-result.test.ts
@@ -143,6 +143,14 @@ describe("Tool Call Without Result Tests", () => {
 		});
 	});
 
+	describe.skipIf(!process.env.ABLITERATION_API_KEY)("abliteration.ai Provider", () => {
+		const model = getModel("abliteration", "abliterated-model-large-v2");
+
+		it("should filter out tool calls without corresponding tool results", { retry: 3, timeout: 30000 }, async () => {
+			await testToolCallWithoutResult(model);
+		});
+	});
+
 	describe.skipIf(!process.env.GROQ_API_KEY)("Groq Provider", () => {
 		const model = getModel("groq", "openai/gpt-oss-20b");
 

--- a/packages/ai/test/total-tokens.test.ts
+++ b/packages/ai/test/total-tokens.test.ts
@@ -235,6 +235,24 @@ describe("totalTokens field", () => {
 		});
 	});
 
+	describe.skipIf(!process.env.ABLITERATION_API_KEY)("abliteration.ai", () => {
+		it("abliterated-model-large-v2 - should return totalTokens equal to sum of components", {
+			retry: 3,
+			timeout: 60000,
+		}, async () => {
+			const llm = getModel("abliteration", "abliterated-model-large-v2");
+
+			console.log(`\nabliteration.ai / ${llm.id}:`);
+			const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.ABLITERATION_API_KEY });
+
+			logUsage("First request", first);
+			logUsage("Second request", second);
+
+			assertTotalTokensEqualsComponents(first);
+			assertTotalTokensEqualsComponents(second);
+		});
+	});
+
 	describe.skipIf(!process.env.GROQ_API_KEY)("Groq", () => {
 		it("openai/gpt-oss-120b - should return totalTokens equal to sum of components", {
 			retry: 3,

--- a/packages/ai/test/unicode-surrogate.test.ts
+++ b/packages/ai/test/unicode-surrogate.test.ts
@@ -457,6 +457,22 @@ describe("AI Providers Unicode Surrogate Pair Tests", () => {
 		});
 	});
 
+	describe.skipIf(!process.env.ABLITERATION_API_KEY)("abliteration.ai Provider Unicode Handling", () => {
+		const llm = getModel("abliteration", "abliterated-model-large-v2");
+
+		it("should handle emoji in tool results", { retry: 3, timeout: 30000 }, async () => {
+			await testEmojiInToolResults(llm);
+		});
+
+		it("should handle real-world LinkedIn comment data with emoji", { retry: 3, timeout: 30000 }, async () => {
+			await testRealWorldLinkedInData(llm);
+		});
+
+		it("should handle unpaired high surrogate (0xD83D) in tool results", { retry: 3, timeout: 30000 }, async () => {
+			await testUnpairedHighSurrogate(llm);
+		});
+	});
+
 	describe.skipIf(!process.env.GROQ_API_KEY)("Groq Provider Unicode Handling", () => {
 		const llm = getModel("groq", "openai/gpt-oss-20b");
 

--- a/packages/coding-agent/.changes/abliteration-provider.md
+++ b/packages/coding-agent/.changes/abliteration-provider.md
@@ -1,0 +1,1 @@
+- Added abliteration.ai provider (`abliterated-model-large-v2` default) to the model catalog via `ABLITERATION_API_KEY`.

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -84,6 +84,7 @@ For each built-in provider, Prime Agent maintains a list of tool-capable models,
 
 **API keys:**
 - Anthropic
+- abliteration.ai
 - audn.ai
 - OpenAI
 - Prime Inference

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -58,6 +58,7 @@ prime-agent
 
 | Provider | Environment Variable | `auth.json` key |
 |----------|----------------------|------------------|
+| abliteration.ai | `ABLITERATION_API_KEY` | `abliteration` |
 | Anthropic | `ANTHROPIC_API_KEY` | `anthropic` |
 | audn.ai | `AUDN_API_KEY` | `audn` |
 | Azure OpenAI Responses | `AZURE_OPENAI_API_KEY` | `azure-openai-responses` |

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -144,6 +144,12 @@ audn.ai is an OpenAI-compatible API at `https://platform.audn.ai/api/v1`. Set `A
 
 See [https://platform.audn.ai/docs](https://platform.audn.ai/docs).
 
+### abliteration.ai
+
+abliteration.ai is an OpenAI Responses-compatible API at `https://api.abliteration.ai/v1`. Set `ABLITERATION_API_KEY` or store a key under `abliteration` via `/login`. Keys start with `ak_`; get one at [https://abliteration.ai](https://abliteration.ai). The default model is `abliterated-model-large-v2`. All three models reason by default (`/effort` maps to `reasoning.effort`): `abliterated-model` (262K context, text+image, `none`–`xhigh`), `abliterated-model-large-v2` (1M context, text-only, native `low` / `high` / `max`), and `abliterated-model-large` (1M context, text-only, native `high` / `max`).
+
+See [https://docs.abliteration.ai](https://docs.abliteration.ai).
+
 ### OrcaRouter
 
 OrcaRouter is an OpenAI-compatible router at `https://api.orcarouter.ai/v1`. Set `ORCAROUTER_API_KEY` (fallback `ORCA_KEY`) or store a key under `orcarouter` via `/login`. Keys start with `sk-orca-`; get one at [https://www.orcarouter.ai](https://www.orcarouter.ai). The default model is `orcarouter/auto`.

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -19,6 +19,7 @@ export const PRIME_INFERENCE_DEFAULT_MODEL_ID = "z-ai/glm-5.2";
 /** Default model IDs for each known provider */
 export const defaultModelPerProvider: Record<KnownProvider, string> = {
 	"amazon-bedrock": "us.anthropic.claude-opus-4-6-v1",
+	abliteration: "abliterated-model-large-v2",
 	anthropic: "claude-opus-4-7",
 	audn: "necromicon",
 	openai: "gpt-5.4",

--- a/packages/coding-agent/src/core/provider-display-names.ts
+++ b/packages/coding-agent/src/core/provider-display-names.ts
@@ -1,4 +1,5 @@
 export const BUILT_IN_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+	abliteration: "abliteration.ai",
 	anthropic: "Anthropic",
 	audn: "audn.ai",
 	"amazon-bedrock": "Amazon Bedrock",

--- a/packages/coding-agent/test/abliteration-provider.test.ts
+++ b/packages/coding-agent/test/abliteration-provider.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "vitest";
+import { defaultModelPerProvider } from "../src/core/model-resolver.js";
+import { BUILT_IN_PROVIDER_DISPLAY_NAMES } from "../src/core/provider-display-names.js";
+
+describe("abliteration.ai provider wiring", () => {
+	test("default model is abliterated-model-large-v2", () => {
+		expect(defaultModelPerProvider.abliteration).toBe("abliterated-model-large-v2");
+	});
+
+	test("login display name is abliteration.ai", () => {
+		expect(BUILT_IN_PROVIDER_DISPLAY_NAMES.abliteration).toBe("abliteration.ai");
+	});
+});

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -314,6 +314,10 @@ describe("default model selection", () => {
 		expect(defaultModelPerProvider.audn).toBe("necromicon");
 	});
 
+	test("abliteration defaults to abliterated-model-large-v2", () => {
+		expect(defaultModelPerProvider.abliteration).toBe("abliterated-model-large-v2");
+	});
+
 	test("ai-gateway default tracks current model", () => {
 		expect(defaultModelPerProvider["vercel-ai-gateway"]).toBe("zai/glm-5.1");
 	});

--- a/prime-agent.ps1
+++ b/prime-agent.ps1
@@ -33,6 +33,7 @@ if ($noEnvironment) {
 	$credentialVariables = @(
 		"ANTHROPIC_API_KEY",
 		"ANTHROPIC_OAUTH_TOKEN",
+		"ABLITERATION_API_KEY",
 		"AUDN_API_KEY",
 		"OPENAI_API_KEY",
 		"PRIME_API_KEY",

--- a/prime-agent.sh
+++ b/prime-agent.sh
@@ -25,6 +25,7 @@ if [[ "$NO_ENV" == "true" ]]; then
   # Unset API keys (see packages/ai/src/env-api-keys.ts)
   unset ANTHROPIC_API_KEY
   unset ANTHROPIC_OAUTH_TOKEN
+  unset ABLITERATION_API_KEY
   unset AUDN_API_KEY
   unset OPENAI_API_KEY
   unset PRIME_API_KEY

--- a/test.sh
+++ b/test.sh
@@ -25,6 +25,7 @@ export PI_NO_LOCAL_LLM=1
 # Unset API keys (see packages/ai/src/stream.ts getEnvApiKey)
 unset ANTHROPIC_API_KEY
 unset ANTHROPIC_OAUTH_TOKEN
+unset ABLITERATION_API_KEY
 unset AUDN_API_KEY
 unset OPENAI_API_KEY
 unset GEMINI_API_KEY


### PR DESCRIPTION
Adds abliteration.ai (\https://api.abliteration.ai/v1\) as a built-in OpenAI Responses-compatible provider (\ABLITERATION_API_KEY\, keys start with \k_\).

Models (per https://docs.abliteration.ai):
- \bliterated-model-large-v2\ (default, featured) - 1M context, 999990 max output, text-only, GLM-5.3, native \low\/\high\/\max\ effort, default \max\, \/1M in+out, \.50/1M cache read
- \bliterated-model-large\ - 1M context, 999990 max output, text-only, GLM-5.2, native \high\/\max\, \/1M
- \bliterated-model\ - 262144 context, 262134 max output, text+image, \
one\-\xhigh\ (no \max\ on Responses), \/1M

Effort aliases follow the documented server mapping (large-v2: none/minimal/low->low, medium/high->high, xhigh/max->max; large: minimal-high->high, xhigh-max->max).

Verification:
- \
pm run check\ passes (biome, tsgo, installer, browser-smoke)
- New \packages/ai/test/abliteration-models.test.ts\: catalog metadata + mocked-SDK payload tests confirming base URL, \model\+\stream:true\+\easoning.effort\ shape matching the reference curl, and alias mappings (12 tests pass)
- E2E matrix entries added (stream, tokens, abort, empty, context-overflow, unicode-surrogate, tool-call-without-result, total-tokens, image-tool-result for the image-capable base model, cross-provider-handoff); all skip without \ABLITERATION_API_KEY\
- Live E2E not run - no API key in this environment; needs a keyed run before merge

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds abliteration.ai as a built-in OpenAI Responses-compatible provider with three models, making `abliterated-model-large-v2` the new default.

**New Features**
- `abliterated-model-large-v2`: 1M context, text-only, native `low`/`high`/`max` reasoning effort (default `max`).
- `abliterated-model-large`: 1M context, text-only, native `high`/`max`.
- `abliterated-model`: 262K context, text+image, `none`–`xhigh`, no `max` on Responses.
- Reasoning effort aliases map to each model's native levels.
- Set `ABLITERATION_API_KEY` to authenticate; keys start with `ak_`.

E2E coverage was added but skipped without a key, so a live keyed run is still needed before merge.

<sup>Written for commit 9afea66ba0a85afd456d7f6050053c6f56bcd6ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LuciferMornens/oneharness/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the Abliteration.ai provider.
  - Added three models with reasoning controls, multimodal inputs, streaming, tool calling, and context and token limits.
  - Added a default model for coding-agent usage.
  - Added API-key configuration through `ABLITERATION_API_KEY`.

- **Documentation**
  - Documented provider setup, endpoint, authentication, supported models, capabilities, and reasoning behavior.

- **Tests**
  - Added coverage for streaming, tool use, token usage, abort handling, context limits, Unicode, images, and model configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->