### PR TITLE
fix: enable GPT-6 Astra for Codex subscriptions

### DIFF
--- a/packages/ai/.changes/gpt-6-astra-subscription.md
+++ b/packages/ai/.changes/gpt-6-astra-subscription.md
@@ -1,0 +1,1 @@
+- Added GPT-6 Astra to the OpenAI Codex subscription catalog with low, medium, high, xhigh, and max reasoning levels.

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -2587,6 +2587,26 @@ function updatePreservedReasoningMetadata(model: Model<any>): void {
 	syncLegacyThinkingLevelMap(model);
 }
 
+function getCodexAstraModel(): Model<"openai-codex-responses"> {
+	return {
+		id: "gpt-6-astra",
+		name: "GPT-6 Astra",
+		api: "openai-codex-responses",
+		provider: "openai-codex",
+		baseUrl: "https://chatgpt.com/backend-api",
+		reasoning: true,
+		reasoningCapabilities: {
+			control: "effort",
+			levels: { off: null, minimal: null, low: "low", medium: "medium", high: "high", xhigh: "xhigh", max: "max" },
+		},
+		input: ["text", "image"],
+		cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+		// Default subscription window from the Codex catalog, not the API's 1.05M window.
+		contextWindow: 272000,
+		maxTokens: 128000,
+	};
+}
+
 const GROK_CLI_PROXY_BASE_URL = "https://cli-chat-proxy.grok.com/v1";
 
 /**
@@ -2930,6 +2950,7 @@ function mergeCatalogModels(allModels: Model<any>[], extra: Model<any>[]): void 
 
 function mergeStaticCatalogModels(allModels: Model<any>[]): void {
 	mergeCatalogModels(allModels, [
+		getCodexAstraModel(),
 		...getGrokSubscriptionModels(),
 		...getAudnModels(),
 		...getAbliterationModels(),
@@ -3382,6 +3403,7 @@ async function generateModels() {
 	const CODEX_CONTEXT = 272000;
 	const CODEX_MAX_TOKENS = 128000;
 	const codexModels: Model<"openai-codex-responses">[] = [
+		getCodexAstraModel(),
 		{
 			id: "gpt-5.1",
 			name: "GPT-5.1",

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -9864,6 +9864,25 @@ export const MODELS = {
 			contextWindow: 272000,
 			maxTokens: 128000,
 		} satisfies Model<"openai-codex-responses">,
+		"gpt-6-astra": {
+			id: "gpt-6-astra",
+			name: "GPT-6 Astra",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			thinkingLevelMap: {"off":null,"minimal":null,"low":"low","medium":"medium","high":"high","xhigh":"xhigh","max":"max"},
+			reasoningCapabilities: {"control":"effort","levels":{"off":null,"minimal":null,"low":"low","medium":"medium","high":"high","xhigh":"xhigh","max":"max"}},
+			input: ["text", "image"],
+			cost: {
+				input: 10,
+				output: 50,
+				cacheRead: 1,
+				cacheWrite: 12.5,
+			},
+			contextWindow: 272000,
+			maxTokens: 128000,
+		} satisfies Model<"openai-codex-responses">,
 	},
 	"opencode": {
 		"big-pickle": {

--- a/packages/ai/test/codex-astra.test.ts
+++ b/packages/ai/test/codex-astra.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getModel, getSupportedThinkingLevels } from "../src/models.js";
+import { streamSimpleOpenAICodexResponses } from "../src/providers/openai-codex-responses.js";
+import type { Context } from "../src/types.js";
+
+const efforts = ["low", "medium", "high", "xhigh", "max"] as const;
+const token = `test.${Buffer.from(
+	JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "astra-test-account" } }),
+).toString("base64url")}.test`;
+const context: Context = {
+	systemPrompt: "You are a helpful assistant.",
+	messages: [{ role: "user", content: "Say hello", timestamp: 0 }],
+};
+
+function mockResponses() {
+	const events = [
+		{ type: "response.output_item.added", item: { type: "message", id: "msg_1", role: "assistant", content: [] } },
+		{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+		{ type: "response.output_text.delta", delta: "Hello" },
+		{
+			type: "response.output_item.done",
+			item: {
+				type: "message",
+				id: "msg_1",
+				role: "assistant",
+				content: [{ type: "output_text", text: "Hello" }],
+			},
+		},
+		{ type: "response.completed", response: { status: "completed" } },
+	];
+	const fetchMock = vi.fn<typeof fetch>().mockImplementation(
+		async () =>
+			new Response(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""), {
+				headers: { "content-type": "text/event-stream" },
+			}),
+	);
+	vi.stubGlobal("fetch", fetchMock);
+	return fetchMock;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("GPT-6 Astra Codex subscription", () => {
+	it("registers the subscription endpoint, limits, and exact reasoning choices", () => {
+		const model = getModel("openai-codex", "gpt-6-astra");
+		expect(model).toMatchObject({
+			api: "openai-codex-responses",
+			baseUrl: "https://chatgpt.com/backend-api",
+			contextWindow: 272000,
+			maxTokens: 128000,
+			input: ["text", "image"],
+		});
+		expect(getSupportedThinkingLevels(model)).toEqual(efforts);
+	});
+
+	it.each(efforts)("sends %s reasoning unchanged with ChatGPT OAuth", async (reasoning) => {
+		const fetchMock = mockResponses();
+		const result = await streamSimpleOpenAICodexResponses(getModel("openai-codex", "gpt-6-astra"), context, {
+			apiKey: token,
+			transport: "sse",
+			reasoning,
+		}).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toEqual([expect.objectContaining({ type: "text", text: "Hello" })]);
+		expect(fetchMock).toHaveBeenCalledOnce();
+		const [url, init] = fetchMock.mock.calls[0]!;
+		expect(url).toBe("https://chatgpt.com/backend-api/codex/responses");
+		const headers = new Headers(init?.headers);
+		expect(headers.get("Authorization")).toBe(`Bearer ${token}`);
+		expect(headers.get("chatgpt-account-id")).toBe("astra-test-account");
+		expect(headers.has("x-api-key")).toBe(false);
+		expect(JSON.parse(String(init?.body))).toMatchObject({
+			model: "gpt-6-astra",
+			store: false,
+			stream: true,
+			reasoning: { effort: reasoning, summary: "auto" },
+		});
+	});
+
+	it.each(["off", "minimal"] as const)("clamps unsupported %s reasoning to low", async (reasoning) => {
+		const fetchMock = mockResponses();
+		const result = await streamSimpleOpenAICodexResponses(getModel("openai-codex", "gpt-6-astra"), context, {
+			apiKey: token,
+			transport: "sse",
+			reasoning,
+		}).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toMatchObject({
+			reasoning: { effort: "low" },
+		});
+	});
+
+	it("preserves the server reasoning default when no effort is selected", async () => {
+		const fetchMock = mockResponses();
+		const result = await streamSimpleOpenAICodexResponses(getModel("openai-codex", "gpt-6-astra"), context, {
+			apiKey: token,
+			transport: "sse",
+		}).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).not.toHaveProperty("reasoning");
+	});
+});

--- a/packages/coding-agent/.changes/gpt-6-astra-subscription.md
+++ b/packages/coding-agent/.changes/gpt-6-astra-subscription.md
@@ -1,0 +1,1 @@
+- Fixed Codex subscription model discovery omitting GPT-6 Astra from available subagent models.

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -506,7 +506,7 @@ function readOpenAICodexAccountId(token: string): string | undefined {
  *
  * Catalog behaviour measured 2026-08-13; see #702.
  */
-const OPENAI_CODEX_CLIENT_VERSION = "0.147.0";
+const OPENAI_CODEX_CLIENT_VERSION = "0.153.0";
 
 function openAICodexModelsUrl(baseUrl: string): string {
 	const normalized = baseUrl.replace(/\/+$/, "");

--- a/packages/coding-agent/test/codex-astra.test.ts
+++ b/packages/coding-agent/test/codex-astra.test.ts
@@ -1,0 +1,81 @@
+import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { ModelRegistry } from "../src/core/model-registry.js";
+import { resolveCliModel } from "../src/core/model-resolver.js";
+
+const efforts = ["low", "medium", "high", "xhigh", "max"] as const;
+const token = `test.${Buffer.from(
+	JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "astra-test-account" } }),
+).toString("base64url")}.test`;
+
+function subscriptionRegistry(): ModelRegistry {
+	return ModelRegistry.inMemory(
+		AuthStorage.inMemory(
+			{
+				"openai-codex": {
+					type: "oauth",
+					access: token,
+					refresh: "unused-test-refresh",
+					expires: Date.now() + 3_600_000,
+				},
+			},
+			{ usePrimeCliConfig: false },
+		),
+	);
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("GPT-6 Astra subscription selection", () => {
+	it("is available with existing Codex OAuth credentials", async () => {
+		const registry = subscriptionRegistry();
+		const model = registry.find("openai-codex", "gpt-6-astra");
+		expect(model).toBeDefined();
+		expect(registry.getAvailable()).toContain(model);
+		expect(registry.isUsingOAuth(model!)).toBe(true);
+		expect(await registry.getApiKeyAndHeaders(model!)).toMatchObject({ ok: true, apiKey: token });
+		expect(getSupportedThinkingLevels(model!)).toEqual(efforts);
+	});
+
+	it.each(efforts)("resolves the subscription model with the %s effort suffix", (effort) => {
+		const result = resolveCliModel({
+			modelRegistry: subscriptionRegistry(),
+			cliModel: `openai-codex/gpt-6-astra:${effort}`,
+		});
+		expect(result.error).toBeUndefined();
+		expect(result.model).toMatchObject({ provider: "openai-codex", id: "gpt-6-astra" });
+		expect(result.thinkingLevel).toBe(effort);
+	});
+
+	it("discovers Astra for subagents using an Astra-capable Codex client version", async () => {
+		const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+			const url = new URL(String(input));
+			const version = url.searchParams.get("client_version")?.split(".").map(Number) ?? [];
+			const supportsAstra = (version[0] ?? 0) > 0 || (version[1] ?? 0) >= 153;
+			return Response.json({ models: supportsAstra ? [{ slug: "gpt-6-astra" }] : [] });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+		const registry = subscriptionRegistry();
+		const executable = await registry.getExecutableModels();
+
+		expect(executable.filter((model) => model.provider === "openai-codex")).toEqual([
+			expect.objectContaining({ id: "gpt-6-astra", api: "openai-codex-responses" }),
+		]);
+		expect(fetchMock).toHaveBeenCalledOnce();
+		const [url, init] = fetchMock.mock.calls[0]!;
+		expect(new URL(String(url)).pathname).toBe("/backend-api/codex/models");
+		expect(new Headers(init?.headers).get("Authorization")).toBe(`Bearer ${token}`);
+		expect(new Headers(init?.headers).get("chatgpt-account-id")).toBe("astra-test-account");
+	});
+
+	it("keeps Astra unavailable to subagents when the account catalog does not include it", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn<typeof fetch>().mockResolvedValue(Response.json({ models: [{ slug: "gpt-5.6-sol" }] })),
+		);
+		const executable = await subscriptionRegistry().getExecutableModels();
+		expect(executable.some((model) => model.provider === "openai-codex" && model.id === "gpt-6-astra")).toBe(false);
+		expect(executable.some((model) => model.provider === "openai-codex" && model.id === "gpt-5.6-sol")).toBe(true);
+	});
+});


### PR DESCRIPTION
GPT-6 Astra was missing from the explicit Codex subscription catalog. Model discovery also reported Codex client version 0.147.0, which hides Astra from the authenticated backend catalog and prevents subagents from selecting it.

Added `openai-codex/gpt-6-astra` with `low`, `medium`, `high`, `xhigh`, and `max` reasoning, the subscription catalog's 272k default context window, and a 128k output limit. Both regular and `--preserve-catalog` generation include it. Discovery now reports 0.153.0; account catalog filtering remains in place. Existing ChatGPT OAuth credentials are used.

Validation:
- `npm run check` passed, including pre-commit checks.
- 17 mocked tests passed across the AI and coding-agent packages, covering subscription auth, model selection, exact effort payloads, unsupported-effort clamping, and catalog version gating.
- Authenticated catalog check: Astra absent at 0.147.0 and present at 0.153.0.
- Live smoke through the existing Codex subscription at low effort returned `OK`.

Model effort/output metadata: [OpenAI GPT-6 Astra documentation](https://developers.openai.com/api/docs/models/gpt-6-astra). Subscription context and availability were checked against the authenticated Codex catalog.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added GPT-6 Astra to the OpenAI Codex subscription catalog.
  - Supports multimodal input and reasoning levels from low through max.
  - Includes pricing and catalog availability details.
  - GPT-6 Astra is now discoverable as an available subagent model when supported by the account.

- **Bug Fixes**
  - Improved Codex subscription model discovery to include GPT-6 Astra.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->