### PR TITLE
feat: enable Astra fast mode by default

### DIFF
--- a/packages/ai/.changes/astra-fast-mode.md
+++ b/packages/ai/.changes/astra-fast-mode.md
@@ -1,0 +1,1 @@
+- Added fast mode for GPT-6 Astra through Codex subscriptions and the OpenAI API, enabled by default unless a preference is saved or the API endpoint uses EU data residency.

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -60,7 +60,15 @@ export function supportsFastMode<TApi extends Api>(model: Model<TApi>): boolean 
 		return capabilities?.control === "effort" && capabilities.levels.low != null;
 	}
 	const eligibleId =
-		model.id === "gpt-5.4" || model.id === "gpt-5.5" || model.id === "gpt-5.6" || model.id.startsWith("gpt-5.6-");
+		model.id === "gpt-5.4" ||
+		model.id === "gpt-5.5" ||
+		model.id === "gpt-5.6" ||
+		model.id.startsWith("gpt-5.6-") ||
+		model.id === "gpt-6-astra";
+	// Astra Fast mode is unavailable with EU API data residency.
+	if (model.id === "gpt-6-astra" && /^https:\/\/eu\.api\.openai\.com(?:[/:]|$)/i.test(model.baseUrl)) {
+		return false;
+	}
 	return (
 		eligibleId &&
 		((model.provider === "openai-codex" && model.api === "openai-codex-responses") ||
@@ -70,7 +78,7 @@ export function supportsFastMode<TApi extends Api>(model: Model<TApi>): boolean 
 
 /** Default service tier when the user has not saved a preference. */
 export function defaultServiceTierForModel<TApi extends Api>(model: Model<TApi> | undefined | null): ServiceTier {
-	if (model && model.provider === "openai-codex" && supportsFastMode(model)) {
+	if (model && (model.provider === "openai-codex" || model.id === "gpt-6-astra") && supportsFastMode(model)) {
 		return "priority";
 	}
 	return "default";

--- a/packages/ai/test/codex-astra.test.ts
+++ b/packages/ai/test/codex-astra.test.ts
@@ -53,12 +53,17 @@ describe("GPT-6 Astra Codex subscription", () => {
 		expect(getSupportedThinkingLevels(model)).toEqual(efforts);
 	});
 
-	it.each(efforts)("sends %s reasoning unchanged with ChatGPT OAuth", async (reasoning) => {
+	it.each(
+		efforts.flatMap((reasoning) =>
+			(["priority", "default"] as const).map((serviceTier) => ({ reasoning, serviceTier })),
+		),
+	)("sends $reasoning reasoning unchanged with $serviceTier processing", async ({ reasoning, serviceTier }) => {
 		const fetchMock = mockResponses();
 		const result = await streamSimpleOpenAICodexResponses(getModel("openai-codex", "gpt-6-astra"), context, {
 			apiKey: token,
 			transport: "sse",
 			reasoning,
+			serviceTier,
 		}).result();
 
 		expect(result.stopReason).toBe("stop");
@@ -74,6 +79,7 @@ describe("GPT-6 Astra Codex subscription", () => {
 			model: "gpt-6-astra",
 			store: false,
 			stream: true,
+			service_tier: serviceTier,
 			reasoning: { effort: reasoning, summary: "auto" },
 		});
 	});

--- a/packages/ai/test/fast-mode.test.ts
+++ b/packages/ai/test/fast-mode.test.ts
@@ -19,7 +19,7 @@ function model(provider: string, id: string, api: Api): Model<Api> {
 }
 
 describe("Fast mode", () => {
-	it.each(["gpt-5.4", "gpt-5.5", "gpt-5.6-luna"])("supports %s through ChatGPT auth", (id) => {
+	it.each(["gpt-5.4", "gpt-5.5", "gpt-5.6-luna", "gpt-6-astra"])("supports %s through ChatGPT auth", (id) => {
 		expect(supportsFastMode(model("openai-codex", id, "openai-codex-responses"))).toBe(true);
 	});
 
@@ -41,8 +41,25 @@ describe("Fast mode", () => {
 		expect(buildBaseOptions(testModel, { serviceTier: "priority" }).serviceTier).toBe("priority");
 	});
 
-	it.each(["gpt-5.4", "gpt-5.5", "gpt-5.6-sol", "gpt-5.6-luna"])("defaults ChatGPT-auth %s to priority", (id) => {
-		expect(defaultServiceTierForModel(model("openai-codex", id, "openai-codex-responses"))).toBe("priority");
+	it.each(["gpt-5.4", "gpt-5.5", "gpt-5.6-sol", "gpt-5.6-luna", "gpt-6-astra"])(
+		"defaults ChatGPT-auth %s to priority",
+		(id) => {
+			expect(defaultServiceTierForModel(model("openai-codex", id, "openai-codex-responses"))).toBe("priority");
+		},
+	);
+
+	it("defaults native API Astra to fast and forwards an explicit off preference", () => {
+		const astra = model("openai", "gpt-6-astra", "openai-responses");
+		expect(supportsFastMode(astra)).toBe(true);
+		expect(defaultServiceTierForModel(astra)).toBe("priority");
+		expect(buildBaseOptions(astra, { serviceTier: "default" }).serviceTier).toBe("default");
+		expect(defaultServiceTierForModel(model("openrouter", "gpt-6-astra", "openai-completions"))).toBe("default");
+	});
+
+	it("keeps Astra standard on the EU API data-residency endpoint", () => {
+		const astra = { ...model("openai", "gpt-6-astra", "openai-responses"), baseUrl: "https://eu.api.openai.com/v1" };
+		expect(supportsFastMode(astra)).toBe(false);
+		expect(defaultServiceTierForModel(astra)).toBe("default");
 	});
 
 	it("does not default API-key GPT or Grok models to priority", () => {

--- a/packages/coding-agent/.changes/astra-fast-mode.md
+++ b/packages/coding-agent/.changes/astra-fast-mode.md
@@ -1,0 +1,1 @@
+- Enabled `/fast` to toggle GPT-6 Astra fast mode without changing reasoning effort, while preserving saved off preferences.

--- a/packages/coding-agent/test/interactive-mode-effort-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-effort-command.test.ts
@@ -357,6 +357,25 @@ describe("InteractiveMode /effort", () => {
 	});
 
 	describe("Fast mode", () => {
+		it.each(["low", "medium", "high", "xhigh", "max"] as const)(
+			"toggles Astra fast off and on without changing %s reasoning",
+			async (thinkingLevel) => {
+				const context = makeFastContext(testModel("openai-codex", "gpt-6-astra", "openai-codex-responses"));
+				context.connectionState = { sessionId: "session-1", serviceTier: "priority", thinkingLevel };
+				fastInteractiveModePrototype.handleFastCommand.call(context);
+				await context.fastModeToggleQueue;
+				expect(context.showStatus).toHaveBeenLastCalledWith("Fast mode: off");
+				expect(context.connectionState).toMatchObject({ serviceTier: "default", thinkingLevel });
+				fastInteractiveModePrototype.handleFastCommand.call(context);
+				await context.fastModeToggleQueue;
+				expect(context.showStatus).toHaveBeenLastCalledWith("Fast mode: on");
+				expect(context.connectionState).toMatchObject({ serviceTier: "priority", thinkingLevel });
+				expect(fastInteractiveModePrototype.getModelTrayLabel.call(context)).toBe(
+					`gpt-6-astra • ${thinkingLevel} • fast`,
+				);
+			},
+		);
+
 		it("enables Fast mode and refreshes the model tray", async () => {
 			const context = makeFastContext();
 

--- a/packages/coding-agent/test/suite/regressions/4620-fast-mode-settings.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4620-fast-mode-settings.test.ts
@@ -19,22 +19,25 @@ describe("ENG-4620 fast mode settings", () => {
 		harness = undefined;
 	});
 
-	it("defaults ChatGPT-auth GPT models to fast when no preference is saved", async () => {
+	it.each(["gpt-5.6-sol", "gpt-6-astra"])(
+		"defaults ChatGPT-auth %s to fast when no preference is saved",
+		async (id) => {
+			harness = await createHarness({
+				api: "openai-codex-responses",
+				provider: "openai-codex",
+				models: [{ id }],
+			});
+
+			expect(harness.settingsManager.getConfiguredDefaultServiceTier()).toBeUndefined();
+			expect(harness.session.serviceTier).toBe("priority");
+		},
+	);
+
+	it.each(["gpt-5.6-sol", "gpt-6-astra"])("keeps an explicit off preference over the %s fast default", async (id) => {
 		harness = await createHarness({
 			api: "openai-codex-responses",
 			provider: "openai-codex",
-			models: [{ id: "gpt-5.6-sol" }],
-		});
-
-		expect(harness.settingsManager.getConfiguredDefaultServiceTier()).toBeUndefined();
-		expect(harness.session.serviceTier).toBe("priority");
-	});
-
-	it("keeps an explicit default preference over the ChatGPT-auth fast default", async () => {
-		harness = await createHarness({
-			api: "openai-codex-responses",
-			provider: "openai-codex",
-			models: [{ id: "gpt-5.6-sol" }],
+			models: [{ id }],
 		});
 		const currentHarness = harness;
 
@@ -83,6 +86,17 @@ describe("ENG-4620 fast mode settings", () => {
 		const { session: nextSession } = await createSession();
 		sessions.push(nextSession);
 		expect(nextSession.serviceTier).toBe("default");
+	});
+
+	it("defaults API Astra to fast and persists toggling it off and back on", async () => {
+		harness = await createHarness({ api: "openai-responses", provider: "openai", models: [{ id: "gpt-6-astra" }] });
+		expect(harness.session.serviceTier).toBe("priority");
+		harness.session.setServiceTier("default");
+		expect(harness.session.serviceTier).toBe("default");
+		expect(harness.settingsManager.getConfiguredDefaultServiceTier()).toBe("default");
+		harness.session.setServiceTier("priority");
+		expect(harness.session.serviceTier).toBe("priority");
+		expect(harness.settingsManager.getConfiguredDefaultServiceTier()).toBe("priority");
 	});
 
 	it("persists the preference across settings manager restarts", async () => {


### PR DESCRIPTION
Astra was available through Codex subscriptions but failed the model allowlist behind `/fast`. Added native Codex and OpenAI API support and defaulted new Astra sessions to priority processing when no service-tier preference is saved. `/fast` toggles off and back on without changing the selected reasoning effort; saved off preferences remain authoritative. Astra on the EU API data-residency endpoint stays on standard processing.

Validation:
- `npm run check` and pre-commit checks passed.
- 66 targeted tests passed across model eligibility/defaults, request payloads, UI toggling at all five efforts, and session preference persistence.
- Live subscription requests succeeded at low, medium, high, xhigh, and max with `service_tier: priority`; a standard-mode request also succeeded.
- The authenticated Codex catalog advertises `priority` as Fast and `low` as the light reasoning value. This endpoint rejects the newer `fast` wire alias. Responses reported `default` tier metadata even when priority was requested, so live validation proves request acceptance and reasoning support, not an actual latency improvement. Existing Codex tier accounting behavior is unchanged.

References: [Codex speed](https://learn.chatgpt.com/docs/agent-configuration/speed), [API fast mode](https://developers.openai.com/api/docs/guides/fast-mode), [API pricing and EU compatibility](https://developers.openai.com/api/docs/pricing). Codex credit consumption and API token pricing are separate; the documented Astra subscription fast-mode rate is 2.5x standard credits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fast mode support for GPT-6 Astra through Codex subscriptions and the OpenAI API.
  * Fast mode is enabled by default where supported and respects saved preferences.
  * The `/fast` command toggles Astra’s service tier without changing reasoning effort.
  * EU data-residency endpoints continue using standard mode.

* **Bug Fixes**
  * Preserved explicit default-tier settings and Fast mode preferences when switching modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->