### PR TITLE
feat(coding-agent): validate the Windows kernel shell and prove daemon-session concurrency

### DIFF
--- a/packages/coding-agent/.changes/windows-kernel-shell-diagnostics.md
+++ b/packages/coding-agent/.changes/windows-kernel-shell-diagnostics.md
@@ -1,0 +1,1 @@
+- Added the `kernelShellPath` setting for the Python kernel's `bash()`, validated with a fail-closed error naming the problem, and `doctor` now prints the resolved kernel shell. Documented Windows `bash()` limits for PowerShell, output draining, cancellation, and process containment.

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -181,6 +181,7 @@ When a provider requests a retry delay longer than `retry.provider.maxRetryDelay
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `shellPath` | string | - | Custom shell path (e.g., for Cygwin on Windows) |
+| `kernelShellPath` | string | - | Absolute POSIX shell for the Python kernel's `bash()`; use when `shellPath` is PowerShell or Git Bash is outside its default location |
 | `shellCommandPrefix` | string | - | Prefix for every bash command (e.g., `"shopt -s expand_aliases"`) |
 | `npmCommand` | string[] | - | Command argv used for npm package lookup/install operations (e.g., `["mise", "exec", "node@20", "--", "npm"]`) |
 

--- a/packages/coding-agent/docs/windows.md
+++ b/packages/coding-agent/docs/windows.md
@@ -9,7 +9,7 @@ Prime Agent supports native Windows execution from PowerShell, Command Prompt, a
 - npm
 - PowerShell 5.1 or newer; PowerShell 7 (`pwsh`) is preferred
 
-Git for Windows is recommended for projects that use Bash scripts, but Prime Agent can use PowerShell when Bash is not installed.
+Git for Windows is recommended. The command tool can fall back to PowerShell when Bash is not installed, but the Python kernel's `bash()` always needs a POSIX shell (see [Shell Selection](#shell-selection)).
 
 ## Install
 
@@ -80,6 +80,31 @@ or:
 ```
 
 When PowerShell is selected, Prime Agent uses non-interactive `-Command` execution, describes the command tool with PowerShell-native examples, and maps every `%%bash` cell to the configured PowerShell interpreter.
+
+### Kernel Shell
+
+`bash()` inside the Python kernel runs a POSIX shell script and cannot use PowerShell or `cmd.exe`. The kernel resolves its shell separately from the command tool:
+
+1. `kernelShellPath` in `settings.json` (must be an absolute path to an existing POSIX shell)
+2. `shellPath`, when it is a POSIX shell (a PowerShell `shellPath` serves the command tool only)
+3. Git Bash at `C:\Program Files\Git\bin\bash.exe` or `C:\Program Files (x86)\Git\bin\bash.exe`
+
+The kernel never searches `PATH`, `%ProgramFiles%`, or `%LOCALAPPDATA%` for a shell: those are influenced by the environment of the project being worked on. Git installed elsewhere (winget user scope, Scoop, MSYS2) needs an explicit setting:
+
+```json
+{
+  "shellPath": "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+  "kernelShellPath": "C:\\Users\\you\\scoop\\apps\\git\\current\\bin\\bash.exe"
+}
+```
+
+An invalid `kernelShellPath` (relative, missing, or PowerShell/cmd) is not replaced by a fallback: `bash()` raises an error that names the problem. `prime-agent doctor` prints the resolved kernel shell and its source, or the reason none was found.
+
+Windows `bash()` limits compared to POSIX:
+
+- Command exit draining is best-effort. There is no status channel, so a command that leaves background jobs holding the output pipe can end with truncated output.
+- Cancellation cannot interrupt a cell that blocks the event loop in synchronous Python code; it cancels the active task instead. Interrupt-safe cells use `await` points.
+- Job-object containment covers `bash()` children and their descendants. Subprocesses started directly from Python (for example with `subprocess.Popen`) are not contained.
 
 ## IPython Runtime
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -44,7 +44,7 @@
 		"postinstall": "node postinstall.cjs",
 		"prepublishOnly": "npm run clean && npm run build",
 		"bundle": "node scripts/bundle.mjs",
-		"test:kernel": "vitest --run --no-file-parallelism --tagsFilter kernel-heavy test/acp-kernel-features.test.ts test/acp-cold-cli.test.ts test/kernel-goal-skill.test.ts test/repl-kernel-state-roundtrip.test.ts test/repl-kernel-mcp-shutdown.test.ts"
+		"test:kernel": "vitest --run --no-file-parallelism --tagsFilter kernel-heavy test/acp-kernel-features.test.ts test/acp-cold-cli.test.ts test/kernel-goal-skill.test.ts test/repl-kernel-state-roundtrip.test.ts test/repl-kernel-mcp-shutdown.test.ts test/suite/daemon-session-kernel-concurrency.test.ts"
 	},
 	"dependencies": {
 		"@agentclientprotocol/sdk": "^1.3.0",

--- a/packages/coding-agent/src/cli/public-command.ts
+++ b/packages/coding-agent/src/cli/public-command.ts
@@ -4,6 +4,7 @@ import { AuthStorage } from "../core/auth-storage.js";
 import { runMcpManagementCommand } from "../core/mcp/mcp-command.js";
 import { SettingsManager } from "../core/settings-manager.js";
 import { handlePackageCommand, isSelfUpdateSource } from "../package-manager-cli.js";
+import { type KernelShellResolution, resolveKernelShell } from "../utils/shell.js";
 import { INTERNAL_RUNTIME_COMMAND_MARKER, parseArgs } from "./args.js";
 import {
 	findCommandSuggestion,
@@ -252,13 +253,30 @@ async function runStatus(args: string[]): Promise<PublicCommandResult> {
 	return HANDLED;
 }
 
+function formatKernelShellReport(resolution: KernelShellResolution): string {
+	if (!resolution.shell) {
+		return chalk.red(`Kernel shell: none. ${resolution.issue}`);
+	}
+	return `Kernel shell: ${resolution.shell} ${chalk.dim(`(${resolution.source})`)}`;
+}
+
 async function runDoctor(args: string[]): Promise<PublicCommandResult> {
 	const options = parseBooleanOptions(args, new Set(["--fix", "--json"]), "doctor");
 	if (!options) return HANDLED;
+	const json = options.has("--json");
+	// JSON output stays the service report alone; the shell check is a human diagnostic.
+	if (!json) {
+		const settingsManager = SettingsManager.create(process.cwd());
+		const resolution = resolveKernelShell({
+			kernelShellPath: settingsManager.getKernelShellPath(),
+			shellPath: settingsManager.getShellPath(),
+		});
+		console.log(formatKernelShellReport(resolution));
+	}
 	if (options.has("--fix")) {
-		await runReap(options.has("--json"), false);
+		await runReap(json, false);
 	} else {
-		await runPs(options.has("--json"));
+		await runPs(json);
 	}
 	return HANDLED;
 }

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9370,6 +9370,7 @@ export class AgentSession {
 			this._ipythonKernelProvisioner = new IpythonKernelProvisioner(this._cwd, {
 				env: this._rlmKernelEnv(),
 				commandPrefix: this.settingsManager.getShellCommandPrefix(),
+				kernelShellPath: this.settingsManager.getKernelShellPath(),
 				shellPath: this.settingsManager.getShellPath(),
 				sessionId: this.sessionId,
 				hostHandlers: this._createKernelHostHandlers(),

--- a/packages/coding-agent/src/core/kernel/shared.ts
+++ b/packages/coding-agent/src/core/kernel/shared.ts
@@ -48,7 +48,8 @@ export interface KernelManagerOptions {
 	/** Python interpreter with the kernel runtime available. Defaults to the auto-bootstrapped kernel. */
 	python?: string;
 	cwd?: string;
-	env?: Record<string, string>;
+	/** Layered over process.env; an undefined value removes the inherited variable. */
+	env?: Record<string, string | undefined>;
 	sessionId?: string;
 	hostHandlers?: HostRequestHandlers;
 	pythonSkills?: readonly KernelPythonSkill[];

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -159,6 +159,7 @@ export interface Settings {
 	retry?: RetrySettings;
 	hideThinkingBlock?: boolean;
 	shellPath?: string; // Custom shell path (e.g., for Cygwin users on Windows)
+	kernelShellPath?: string; // POSIX shell for the Python kernel's bash() when shellPath is PowerShell or Git Bash is not in its default location
 	quietStartup?: boolean;
 	shellCommandPrefix?: string; // Prefix prepended to every bash command (e.g., "shopt -s expand_aliases" for alias support)
 	npmCommand?: string[]; // Command used for npm package lookup/install operations, argv-style (e.g., ["mise", "exec", "node@20", "--", "npm"])
@@ -996,6 +997,10 @@ export class SettingsManager {
 		this.globalSettings.shellPath = path;
 		this.markModified("shellPath");
 		this.save();
+	}
+
+	getKernelShellPath(): string | undefined {
+		return this.settings.kernelShellPath;
 	}
 
 	getQuietStartup(): boolean {

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -483,11 +483,14 @@ export class IpythonKernelProvisioner {
 			const m = new ReplKernelManager({
 				python: this.options?.python,
 				cwd: this.cwd,
-				// bash() reads these to pick its shell and command prefix.
+				// bash() reads these to pick its shell and command prefix. Both shell
+				// keys are always set so values inherited from the host's own
+				// environment can neither bypass a rejected setting nor poison a
+				// valid one.
 				env: {
 					...this.options?.env,
-					...(kernelShell.shell ? { PRIME_AGENT_BASH_SHELL: kernelShell.shell } : {}),
-					...(kernelShell.issue ? { PRIME_AGENT_BASH_SHELL_ISSUE: kernelShell.issue } : {}),
+					PRIME_AGENT_BASH_SHELL: kernelShell.shell,
+					PRIME_AGENT_BASH_SHELL_ISSUE: kernelShell.issue,
 					...(commandPrefix ? { PRIME_AGENT_BASH_COMMAND_PREFIX: commandPrefix } : {}),
 				},
 				sessionId: this.options?.sessionId,

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -4,7 +4,7 @@ import type { AgentTool } from "@earendil-works/pi-agent-core";
 import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
 import { type Static, Type } from "typebox";
 import { IMAGE_MIME_TYPES } from "../../utils/mime.js";
-import { resolveKernelBashShell } from "../../utils/shell.js";
+import { resolveKernelShell } from "../../utils/shell.js";
 import type { ExtensionContext, ToolDefinition } from "../extensions/types.js";
 import { withKernelBootPermit } from "../kernel/boot-gate.js";
 import type { KernelBootstrapProgressHandler } from "../kernel/bootstrap.js";
@@ -282,7 +282,9 @@ export interface IpythonToolOptions {
 	env?: Record<string, string>;
 	/** Command prefix prepended to every bash() command. */
 	commandPrefix?: string;
-	/** Shell used by bash(). */
+	/** Shell for bash() only; must be a POSIX shell. */
+	kernelShellPath?: string;
+	/** Shell shared with the bash tool; bash() uses it only when it is a POSIX shell. */
 	shellPath?: string;
 	sessionId?: string;
 	/** Typed host request handlers for the kernel↔host bridge (rlm.run, goal.*, …). */
@@ -470,9 +472,12 @@ export class IpythonKernelProvisioner {
 				);
 			}
 			const snapshotDir = this.options?.snapshotDir;
-			// Always inject an absolute trusted shell (undefined only on win32
-			// without bash, where the runtime's teaching error fires instead).
-			const shellPath = resolveKernelBashShell(this.options?.shellPath);
+			// Always inject an absolute trusted shell; without one the runtime's
+			// bash() raises the resolution issue instead of failing kernel startup.
+			const kernelShell = resolveKernelShell({
+				kernelShellPath: this.options?.kernelShellPath,
+				shellPath: this.options?.shellPath,
+			});
 			const commandPrefix = this.options?.commandPrefix;
 			const bootstrapCode = buildRlmBootstrapCode(this.options?.pythonSkills);
 			const m = new ReplKernelManager({
@@ -481,7 +486,8 @@ export class IpythonKernelProvisioner {
 				// bash() reads these to pick its shell and command prefix.
 				env: {
 					...this.options?.env,
-					...(shellPath ? { PRIME_AGENT_BASH_SHELL: shellPath } : {}),
+					...(kernelShell.shell ? { PRIME_AGENT_BASH_SHELL: kernelShell.shell } : {}),
+					...(kernelShell.issue ? { PRIME_AGENT_BASH_SHELL_ISSUE: kernelShell.issue } : {}),
 					...(commandPrefix ? { PRIME_AGENT_BASH_COMMAND_PREFIX: commandPrefix } : {}),
 				},
 				sessionId: this.options?.sessionId,

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { delimiter, win32 } from "node:path";
+import { delimiter, posix, win32 } from "node:path";
 import type { ChildProcess } from "child_process";
 import { getBinDir } from "../config.js";
 import { recordOrphanProcessState } from "../core/orphan-process-journal.js";
@@ -200,28 +200,89 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 // input, the same trust-laundering class as PATH.
 const WINDOWS_GIT_BASH_PATHS = ["C:\\Program Files\\Git\\bin\\bash.exe", "C:\\Program Files (x86)\\Git\\bin\\bash.exe"];
 
+export interface KernelShellSettings {
+	/** Shell for the kernel's bash() only. Must be a POSIX shell. */
+	kernelShellPath?: string;
+	/** Shell shared with the bash tool; used by the kernel only when it is a POSIX shell. */
+	shellPath?: string;
+}
+
+export type KernelShellSource = "kernelShellPath" | "shellPath" | "system" | "git-bash" | "none";
+
+export interface KernelShellResolution {
+	/** Absolute shell path, or undefined when bash() has no usable shell. */
+	shell: string | undefined;
+	source: KernelShellSource;
+	/** Why no shell was selected. Set only when shell is undefined. */
+	issue?: string;
+}
+
+function isWindowsCmdShell(shellPath: string): boolean {
+	const executable = shellPath.replace(/\\/g, "/").split("/").pop()?.toLowerCase() ?? "";
+	return executable === "cmd" || executable === "cmd.exe";
+}
+
+function kernelShellSettingIssue(settingName: string, shellPath: string): string | undefined {
+	const pathModule = process.platform === "win32" ? win32 : posix;
+	if (!pathModule.isAbsolute(shellPath)) {
+		return `${settingName} must be an absolute path: ${shellPath}`;
+	}
+	if (!existsSync(shellPath)) {
+		return `${settingName} does not exist: ${shellPath}`;
+	}
+	if (isPowerShellShell(shellPath) || isWindowsCmdShell(shellPath)) {
+		return `${settingName} must be a POSIX shell; bash() cannot run under PowerShell or cmd.exe: ${shellPath}`;
+	}
+	return undefined;
+}
+
+function kernelShellFromSetting(
+	settingName: "kernelShellPath" | "shellPath",
+	shellPath: string,
+): KernelShellResolution {
+	const issue = kernelShellSettingIssue(settingName, shellPath);
+	if (issue) {
+		return { shell: undefined, source: "none", issue };
+	}
+	return { shell: shellPath, source: settingName };
+}
+
 /**
- * Absolute default shell for the kernel's bash(): explicit shellPath wins; POSIX
- * uses /bin/bash else /bin/sh (absolute, never PATH — the kernel inherits a
- * user-influenced PATH); win32 uses only the canonical Git Bash install paths,
- * never PATH (a repo-controlled PATH/where.exe must not pick the kernel shell).
- * undefined = no shell found: kernel startup must not fail, bash() raises its
- * teaching error.
+ * Absolute shell for the kernel's bash(). kernelShellPath wins, then a POSIX
+ * shellPath; both are validated and fail closed so a misconfiguration is
+ * reported instead of silently replaced. Without a setting, POSIX uses
+ * /bin/bash else /bin/sh (absolute, never PATH: the kernel inherits a
+ * user-influenced PATH) and win32 uses only the canonical Git Bash install
+ * paths, never PATH (a repo-controlled PATH/where.exe must not pick the shell).
+ * shell undefined never fails kernel startup: bash() raises the issue instead.
  */
-export function resolveKernelBashShell(customShellPath?: string): string | undefined {
-	const explicit = customShellPath?.trim();
-	if (explicit) {
-		return explicit;
+export function resolveKernelShell(settings: KernelShellSettings): KernelShellResolution {
+	const kernelShellPath = settings.kernelShellPath?.trim();
+	if (kernelShellPath) {
+		return kernelShellFromSetting("kernelShellPath", kernelShellPath);
+	}
+	const sharedShellPath = settings.shellPath?.trim();
+	if (sharedShellPath && !isPowerShellShell(sharedShellPath) && !isWindowsCmdShell(sharedShellPath)) {
+		return kernelShellFromSetting("shellPath", sharedShellPath);
 	}
 	if (process.platform !== "win32") {
-		return existsSync("/bin/bash") ? "/bin/bash" : "/bin/sh";
+		return { shell: existsSync("/bin/bash") ? "/bin/bash" : "/bin/sh", source: "system" };
 	}
 	for (const path of WINDOWS_GIT_BASH_PATHS) {
 		if (existsSync(path)) {
-			return path;
+			return { shell: path, source: "git-bash" };
 		}
 	}
-	return undefined;
+	const sharedShellNote = sharedShellPath
+		? ` shellPath (${sharedShellPath}) serves the bash tool only; bash() needs a POSIX shell.`
+		: "";
+	return {
+		shell: undefined,
+		source: "none",
+		issue:
+			"No POSIX shell for bash(): install Git for Windows in its default location " +
+			`or set kernelShellPath in settings.json.${sharedShellNote}`,
+	};
 }
 
 export function getShellEnv(): NodeJS.ProcessEnv {

--- a/packages/coding-agent/test/fixtures/daemon-kernel-concurrency-faux-extension.ts
+++ b/packages/coding-agent/test/fixtures/daemon-kernel-concurrency-faux-extension.ts
@@ -1,0 +1,57 @@
+import { fauxAssistantMessage, fauxToolCall, getApiProvider, registerFauxProvider } from "../../../ai/src/index.js";
+import type { ExtensionAPI } from "../../src/index.js";
+
+/**
+ * Faux provider for the daemon-session kernel concurrency proof.
+ *
+ * Every CLI process loads this extension inside its own daemon worker, so each
+ * worker gets a private two-step response queue:
+ *
+ *  1. An ipython tool call that prints the kernel process identity and the
+ *     owner pid the ReplKernelManager stamps into the kernel environment.
+ *  2. A final assistant message that reports the worker process identity;
+ *     the worker's parent is the daemon supervisor that spawned it.
+ */
+const kernelIdentityCode = [
+	"import os",
+	"import sys",
+	'owner_pid = os.environ["PRIME_AGENT_KERNEL_OWNER_PID"]',
+	'print(f"KERNEL_PID={os.getpid()} KERNEL_OWNER_PID={owner_pid} PY={sys.executable}")',
+].join("\n");
+
+const workerIdentityText = `WORKER_PID=${process.pid} SUPERVISOR_PID=${process.ppid}`;
+
+export default function registerDaemonKernelConcurrencyFauxProvider(pi: ExtensionAPI): void {
+	const faux = registerFauxProvider({
+		provider: "faux",
+		models: [{ id: "faux", reasoning: false }],
+	});
+
+	faux.setResponses([
+		fauxAssistantMessage([fauxToolCall("ipython", { code: kernelIdentityCode })], { stopReason: "toolUse" }),
+		fauxAssistantMessage(workerIdentityText),
+	]);
+
+	const apiProvider = getApiProvider(faux.api);
+	if (!apiProvider) {
+		throw new Error("Faux API provider was not registered");
+	}
+
+	pi.registerProvider(faux.getModel().provider, {
+		api: faux.api,
+		apiKey: "faux-key",
+		baseUrl: faux.getModel().baseUrl,
+		streamSimple: apiProvider.streamSimple,
+		models: faux.models.map((model) => ({
+			api: model.api,
+			baseUrl: model.baseUrl,
+			contextWindow: model.contextWindow,
+			cost: model.cost,
+			id: model.id,
+			input: model.input,
+			maxTokens: model.maxTokens,
+			name: model.name,
+			reasoning: model.reasoning,
+		})),
+	});
+}

--- a/packages/coding-agent/test/fixtures/daemon-kernel-concurrency-faux-extension.ts
+++ b/packages/coding-agent/test/fixtures/daemon-kernel-concurrency-faux-extension.ts
@@ -7,16 +7,34 @@ import type { ExtensionAPI } from "../../src/index.js";
  * Every CLI process loads this extension inside its own daemon worker, so each
  * worker gets a private two-step response queue:
  *
- *  1. An ipython tool call that prints the kernel process identity and the
- *     owner pid the ReplKernelManager stamps into the kernel environment.
+ *  1. An ipython tool call that registers the kernel at a file barrier, waits
+ *     until every expected kernel has arrived, then prints the kernel process
+ *     identity and the owner pid the ReplKernelManager stamps into the kernel
+ *     environment. Only overlapping kernels can all see a full barrier.
  *  2. A final assistant message that reports the worker process identity;
  *     the worker's parent is the daemon supervisor that spawned it.
+ *
+ * The barrier lives beside the session's working directory: the test creates
+ * `<root>/barrier/expected` holding the kernel count and starts each session
+ * in `<root>/cwd-<index>`.
  */
+const BARRIER_WAIT_SECONDS = 90;
+
 const kernelIdentityCode = [
 	"import os",
 	"import sys",
+	"import time",
+	'barrier = os.path.join(os.path.dirname(os.getcwd()), "barrier")',
+	'with open(os.path.join(barrier, "expected"), encoding="utf-8") as expected_file:',
+	"    expected = int(expected_file.read())",
+	'open(os.path.join(barrier, f"arrived-{os.getpid()}"), "w").close()',
+	"def arrived():",
+	'    return sum(name.startswith("arrived-") for name in os.listdir(barrier))',
+	`deadline = time.monotonic() + ${BARRIER_WAIT_SECONDS}`,
+	"while arrived() < expected and time.monotonic() < deadline:",
+	"    time.sleep(0.1)",
 	'owner_pid = os.environ["PRIME_AGENT_KERNEL_OWNER_PID"]',
-	'print(f"KERNEL_PID={os.getpid()} KERNEL_OWNER_PID={owner_pid} PY={sys.executable}")',
+	'print(f"KERNEL_PID={os.getpid()} KERNEL_OWNER_PID={owner_pid} BARRIER_ARRIVED={arrived()} PY={sys.executable}")',
 ].join("\n");
 
 const workerIdentityText = `WORKER_PID=${process.pid} SUPERVISOR_PID=${process.ppid}`;

--- a/packages/coding-agent/test/kernel-bash-shell.test.ts
+++ b/packages/coding-agent/test/kernel-bash-shell.test.ts
@@ -17,7 +17,7 @@ vi.mock("child_process", async (importOriginal) => {
 	return { ...actual, spawnSync: mocks.spawnSync };
 });
 
-import { orderWindowsBashCandidates, resolveKernelBashShell } from "../src/utils/shell.js";
+import { orderWindowsBashCandidates, resolveKernelShell } from "../src/utils/shell.js";
 
 const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
 
@@ -33,32 +33,82 @@ afterEach(() => {
 	mocks.spawnSync.mockClear();
 });
 
-describe("resolveKernelBashShell on win32", () => {
-	it("returns undefined without consulting PATH when no Git Bash is installed", () => {
+describe("resolveKernelShell on win32", () => {
+	const canonical = "C:\\Program Files\\Git\\bin\\bash.exe";
+	const pwsh = "C:\\Program Files\\PowerShell\\7\\pwsh.exe";
+
+	it("reports an issue without consulting PATH when no Git Bash is installed", () => {
 		stubWin32();
 		mocks.existsSync.mockReturnValue(false);
 
-		expect(resolveKernelBashShell()).toBeUndefined();
-		// The old fallback shelled out to `where bash.exe`; a repo-controlled
-		// PATH/where.exe must never pick the kernel shell.
+		const resolution = resolveKernelShell({});
+		expect(resolution.shell).toBeUndefined();
+		expect(resolution.source).toBe("none");
+		expect(resolution.issue).toContain("kernelShellPath");
+		// A repo-controlled PATH/where.exe must never pick the kernel shell.
 		expect(mocks.spawnSync).not.toHaveBeenCalled();
 	});
 
 	it("returns the canonical Git Bash install path when present", () => {
 		stubWin32();
-		const canonical = "C:\\Program Files\\Git\\bin\\bash.exe";
 		mocks.existsSync.mockImplementation((path: string) => path === canonical);
 
-		expect(resolveKernelBashShell()).toBe(canonical);
+		expect(resolveKernelShell({})).toEqual({ shell: canonical, source: "git-bash" });
 		expect(mocks.spawnSync).not.toHaveBeenCalled();
 	});
 
-	it("returns an explicit shellPath as-is", () => {
+	it("prefers an existing absolute kernelShellPath over Git Bash", () => {
+		stubWin32();
+		mocks.existsSync.mockReturnValue(true);
+
+		expect(resolveKernelShell({ kernelShellPath: "D:\\tools\\bash.exe", shellPath: pwsh })).toEqual({
+			shell: "D:\\tools\\bash.exe",
+			source: "kernelShellPath",
+		});
+	});
+
+	it("uses a POSIX shellPath for the kernel", () => {
+		stubWin32();
+		mocks.existsSync.mockReturnValue(true);
+
+		expect(resolveKernelShell({ shellPath: "D:\\msys64\\usr\\bin\\bash.exe" })).toEqual({
+			shell: "D:\\msys64\\usr\\bin\\bash.exe",
+			source: "shellPath",
+		});
+	});
+
+	it("skips a PowerShell shellPath and explains it when no Git Bash exists", () => {
 		stubWin32();
 		mocks.existsSync.mockReturnValue(false);
 
-		expect(resolveKernelBashShell("D:\\tools\\bash.exe")).toBe("D:\\tools\\bash.exe");
-		expect(mocks.existsSync).not.toHaveBeenCalled();
+		const resolution = resolveKernelShell({ shellPath: pwsh });
+		expect(resolution.shell).toBeUndefined();
+		expect(resolution.issue).toContain(pwsh);
+		expect(resolution.issue).toContain("bash tool only");
+	});
+
+	it("falls through a PowerShell shellPath to Git Bash", () => {
+		stubWin32();
+		mocks.existsSync.mockImplementation((path: string) => path === canonical);
+
+		expect(resolveKernelShell({ shellPath: pwsh })).toEqual({ shell: canonical, source: "git-bash" });
+	});
+
+	it.each([
+		["a relative path", "tools\\bash.exe", true, "absolute"],
+		["a missing file", "D:\\missing\\bash.exe", false, "does not exist"],
+		["PowerShell", pwsh, true, "POSIX shell"],
+		["cmd.exe", "C:\\Windows\\System32\\cmd.exe", true, "POSIX shell"],
+	])("fails closed when kernelShellPath is %s", (_label, kernelShellPath, exists, expectedIssue) => {
+		stubWin32();
+		mocks.existsSync.mockReturnValue(exists);
+
+		const resolution = resolveKernelShell({ kernelShellPath });
+		expect(resolution.shell).toBeUndefined();
+		expect(resolution.source).toBe("none");
+		expect(resolution.issue).toContain("kernelShellPath");
+		expect(resolution.issue).toContain(expectedIssue);
+		expect(mocks.spawnSync).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/coding-agent/test/repl-kernel-execute.test.ts
+++ b/packages/coding-agent/test/repl-kernel-execute.test.ts
@@ -8,14 +8,16 @@ import {
 	AGENT_MESSAGE_DISPLAY_MIME,
 	ATTACHMENT_DISPLAY_MIME,
 	DIFF_DISPLAY_MIME,
+	type ExecuteResult,
 	type HostRequestHandlers,
 	ReplKernelManager,
 } from "../src/core/kernel/index.js";
+import { IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
 
 function resolveReplPython(): string | null {
 	const candidates = [
 		process.env.PRIME_AGENT_KERNEL_PYTHON,
-		resolve(__dirname, "..", "..", "..", "prime-agent-runtime", ".venv", "bin", "python"),
+		kernelVenvPython(resolve(__dirname, "..", "..", "..", "prime-agent-runtime", ".venv")),
 		kernelVenvPython(resolveKernelVenvDirSync()),
 	].filter((p): p is string => Boolean(p));
 	for (const python of candidates) {
@@ -161,5 +163,65 @@ describeIf("ReplKernelManager execute (real runtime)", () => {
 		expect(second.stdout).toContain("own-output");
 		expect(second.stdout).not.toContain("SECRET-thread");
 		expect(second.backgroundOutput ?? "").toContain("SECRET-thread");
+	}, 30_000);
+});
+
+const inheritedShellPath = process.platform === "win32" ? "C:\\Program Files\\Git\\bin\\bash.exe" : "/bin/sh";
+
+/** Runs a provisioner cell with the host's own PRIME_AGENT_BASH_SHELL* variables set to the given values. */
+async function executeWithInheritedShellEnv(
+	dir: string,
+	inherited: { shell?: string; issue?: string },
+	options: { kernelShellPath?: string },
+	code: string,
+): Promise<ExecuteResult> {
+	const saved = { shell: process.env.PRIME_AGENT_BASH_SHELL, issue: process.env.PRIME_AGENT_BASH_SHELL_ISSUE };
+	process.env.PRIME_AGENT_BASH_SHELL = inherited.shell;
+	process.env.PRIME_AGENT_BASH_SHELL_ISSUE = inherited.issue;
+	const provisioner = new IpythonKernelProvisioner(dir, { python: python as string, ...options });
+	try {
+		const client = await provisioner.ensure();
+		return await client.execute(code);
+	} finally {
+		process.env.PRIME_AGENT_BASH_SHELL = saved.shell;
+		process.env.PRIME_AGENT_BASH_SHELL_ISSUE = saved.issue;
+		await provisioner.dispose();
+	}
+}
+
+describeIf("IpythonKernelProvisioner kernel shell env (real runtime)", () => {
+	let dir = "";
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "prime-agent-provisioner-shell-"));
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("removes an inherited shell so a rejected kernelShellPath cannot be bypassed", async () => {
+		const missingShell = join(dir, "missing-shell");
+		const result = await executeWithInheritedShellEnv(
+			dir,
+			{ shell: inheritedShellPath },
+			{ kernelShellPath: missingShell },
+			'import os\nprint(repr(os.environ.get("PRIME_AGENT_BASH_SHELL")))\nbash("echo bypass")',
+		);
+		expect(result.stdout).toContain("None");
+		expect(result.status).toBe("error");
+		expect(result.error?.ename).toBe("RuntimeError");
+		expect(result.error?.evalue).toContain(`kernelShellPath does not exist: ${missingShell}`);
+	}, 30_000);
+
+	it("removes an inherited issue so a resolved shell still runs commands", async () => {
+		const result = await executeWithInheritedShellEnv(
+			dir,
+			{ issue: "stale issue from another process" },
+			{},
+			'print((await bash("echo resolved")).output)',
+		);
+		expect(result.status).toBe("ok");
+		expect(result.stdout).toContain("resolved");
 	}, 30_000);
 });

--- a/packages/coding-agent/test/repl-kernel-execute.test.ts
+++ b/packages/coding-agent/test/repl-kernel-execute.test.ts
@@ -168,6 +168,15 @@ describeIf("ReplKernelManager execute (real runtime)", () => {
 
 const inheritedShellPath = process.platform === "win32" ? "C:\\Program Files\\Git\\bin\\bash.exe" : "/bin/sh";
 
+// Assigning undefined to process.env stores the string "undefined".
+function setHostEnv(name: string, value: string | undefined): void {
+	if (value === undefined) {
+		delete process.env[name];
+	} else {
+		process.env[name] = value;
+	}
+}
+
 /** Runs a provisioner cell with the host's own PRIME_AGENT_BASH_SHELL* variables set to the given values. */
 async function executeWithInheritedShellEnv(
 	dir: string,
@@ -176,15 +185,15 @@ async function executeWithInheritedShellEnv(
 	code: string,
 ): Promise<ExecuteResult> {
 	const saved = { shell: process.env.PRIME_AGENT_BASH_SHELL, issue: process.env.PRIME_AGENT_BASH_SHELL_ISSUE };
-	process.env.PRIME_AGENT_BASH_SHELL = inherited.shell;
-	process.env.PRIME_AGENT_BASH_SHELL_ISSUE = inherited.issue;
+	setHostEnv("PRIME_AGENT_BASH_SHELL", inherited.shell);
+	setHostEnv("PRIME_AGENT_BASH_SHELL_ISSUE", inherited.issue);
 	const provisioner = new IpythonKernelProvisioner(dir, { python: python as string, ...options });
 	try {
 		const client = await provisioner.ensure();
 		return await client.execute(code);
 	} finally {
-		process.env.PRIME_AGENT_BASH_SHELL = saved.shell;
-		process.env.PRIME_AGENT_BASH_SHELL_ISSUE = saved.issue;
+		setHostEnv("PRIME_AGENT_BASH_SHELL", saved.shell);
+		setHostEnv("PRIME_AGENT_BASH_SHELL_ISSUE", saved.issue);
 		await provisioner.dispose();
 	}
 }

--- a/packages/coding-agent/test/suite/daemon-session-kernel-concurrency.test.ts
+++ b/packages/coding-agent/test/suite/daemon-session-kernel-concurrency.test.ts
@@ -9,12 +9,14 @@
  * the whole process chain: supervisor -> worker -> kernel. The worker's parent
  * is the supervisor; the kernel names its owning worker through the
  * PRIME_AGENT_KERNEL_OWNER_PID contract because a Windows venv launcher sits
- * between the worker and the interpreter.
+ * between the worker and the interpreter. Every kernel waits at a file
+ * barrier until all expected kernels have arrived, so distinct pids alone
+ * cannot pass: the kernels must execute at the same time.
  */
 
 import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -224,6 +226,8 @@ function finalAssistantText(events: SessionEvent[]): string {
 interface ProcessChain {
 	kernelPid: number;
 	kernelOwnerPid: number;
+	/** Kernels registered at the barrier when this kernel stopped waiting. */
+	barrierArrived: number;
 	python: string;
 	workerPid: number;
 	supervisorPid: number;
@@ -232,7 +236,7 @@ interface ProcessChain {
 function parseProcessChain(stdout: string): ProcessChain {
 	const events = parseSessionEvents(stdout);
 	const kernelText = ipythonResultText(events);
-	const kernelMatch = /KERNEL_PID=(\d+) KERNEL_OWNER_PID=(\d+) PY=(.+)/.exec(kernelText);
+	const kernelMatch = /KERNEL_PID=(\d+) KERNEL_OWNER_PID=(\d+) BARRIER_ARRIVED=(\d+) PY=(.+)/.exec(kernelText);
 	expect(kernelMatch, `kernel identity missing from ipython result:\n${kernelText}`).not.toBeNull();
 	const workerText = finalAssistantText(events);
 	const workerMatch = /WORKER_PID=(\d+) SUPERVISOR_PID=(\d+)/.exec(workerText);
@@ -240,7 +244,8 @@ function parseProcessChain(stdout: string): ProcessChain {
 	return {
 		kernelPid: Number(kernelMatch?.[1]),
 		kernelOwnerPid: Number(kernelMatch?.[2]),
-		python: (kernelMatch?.[3] ?? "").trim(),
+		barrierArrived: Number(kernelMatch?.[3]),
+		python: (kernelMatch?.[4] ?? "").trim(),
 		workerPid: Number(workerMatch?.[1]),
 		supervisorPid: Number(workerMatch?.[2]),
 	};
@@ -252,12 +257,16 @@ interface DaemonFixture {
 	socketPath: string;
 }
 
-function createDaemonFixture(): DaemonFixture {
+/** Every kernel of the fixture waits at `<root>/barrier` until `expectedKernels` have arrived. */
+function createDaemonFixture(expectedKernels: number): DaemonFixture {
 	const root = mkdtempSync(join(tmpdir(), "prime-agent-kernel-concurrency-"));
 	chmodSync(root, 0o700);
 	tempRoots.add(root);
 	const agentDir = join(root, "agent");
 	mkdirSync(agentDir, { recursive: true });
+	const barrierDir = join(root, "barrier");
+	mkdirSync(barrierDir, { recursive: true });
+	writeFileSync(join(barrierDir, "expected"), String(expectedKernels));
 	const socketPath = daemonSocketPathFor(root);
 	daemonSockets.add(socketPath);
 	return { agentDir, root, socketPath };
@@ -326,9 +335,12 @@ async function expectSingleSupervisor(fixture: DaemonFixture, chains: ProcessCha
 	await expect(readSupervisorPidFromHello(fixture.socketPath)).resolves.toBe(supervisorPid);
 }
 
-function expectKernelOnOverridePython(chain: ProcessChain): void {
+function expectKernelOnOverridePython(chain: ProcessChain, expectedKernels: number): void {
 	expect(chain.kernelPid).toBeGreaterThan(0);
 	expect(chain.kernelOwnerPid).toBe(chain.workerPid);
+	// A kernel only leaves the barrier once every expected kernel has registered,
+	// so a full count proves the kernels were alive at the same time.
+	expect(chain.barrierArrived, "kernel left the barrier before every kernel arrived").toBe(expectedKernels);
 	expect(normalizeExecutablePath(chain.python)).toBe(normalizeExecutablePath(replPython as string));
 }
 
@@ -341,9 +353,9 @@ describeWithKernel(
 		it(
 			"runs one session with its kernel on the override python",
 			async () => {
-				const fixture = createDaemonFixture();
+				const fixture = createDaemonFixture(1);
 				const chain = await runKernelSession(fixture, 0);
-				expectKernelOnOverridePython(chain);
+				expectKernelOnOverridePython(chain, 1);
 				await expectSingleSupervisor(fixture, [chain]);
 			},
 			TEST_TIMEOUT_MS,
@@ -352,12 +364,12 @@ describeWithKernel(
 		it(
 			"runs concurrent sessions on one supervisor and one python with a kernel per session",
 			async () => {
-				const fixture = createDaemonFixture();
+				const fixture = createDaemonFixture(CONCURRENT_SESSION_COUNT);
 				const chains = await Promise.all(
 					Array.from({ length: CONCURRENT_SESSION_COUNT }, (_, index) => runKernelSession(fixture, index)),
 				);
 				for (const chain of chains) {
-					expectKernelOnOverridePython(chain);
+					expectKernelOnOverridePython(chain, CONCURRENT_SESSION_COUNT);
 				}
 				expect(new Set(chains.map((chain) => chain.kernelPid)).size).toBe(CONCURRENT_SESSION_COUNT);
 				expect(new Set(chains.map((chain) => chain.workerPid)).size).toBe(CONCURRENT_SESSION_COUNT);

--- a/packages/coding-agent/test/suite/daemon-session-kernel-concurrency.test.ts
+++ b/packages/coding-agent/test/suite/daemon-session-kernel-concurrency.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Real-process proof that concurrent Prime Agent sessions share one daemon
+ * supervisor and one PRIME_AGENT_KERNEL_PYTHON override while each session
+ * runs its own Python kernel process.
+ *
+ * Spawns the real CLI (`--mode json`) several times at once against one
+ * isolated agent dir. Each run drives a faux model that calls the ipython tool
+ * once and then reports its worker identity, so the JSON event stream carries
+ * the whole process chain: supervisor -> worker -> kernel. The worker's parent
+ * is the supervisor; the kernel names its owning worker through the
+ * PRIME_AGENT_KERNEL_OWNER_PID contract because a Windows venv launcher sits
+ * between the worker and the interpreter.
+ */
+
+import { type ChildProcess, spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ENV_AGENT_DIR } from "../../src/config.js";
+import { kernelVenvPython, resolveKernelVenvDirSync } from "../../src/core/kernel/bootstrap.js";
+import { DaemonClient } from "../../src/modes/daemon/daemon-client.js";
+import { canonicalizeDaemonFilesystemPath, normalizeSocketPath } from "../../src/modes/daemon/daemon-socket.js";
+import {
+	listDaemonSupervisorProcesses,
+	resolveDaemonSupervisorRegistryDir,
+} from "../../src/modes/daemon/daemon-supervisor-ownership.js";
+import { isolatedDaemonProcessEnv, isolatedDaemonRegistryDir, removeTempRoot } from "../isolated-daemon-env.js";
+
+const cliPath = resolve(__dirname, "../../src/cli.ts");
+const tsxPath = resolve(__dirname, "../../../../node_modules/tsx/dist/cli.mjs");
+const repoTsconfigPath = resolve(__dirname, "../../../../tsconfig.json");
+const fauxExtensionPath = resolve(__dirname, "../fixtures/daemon-kernel-concurrency-faux-extension.ts");
+
+const CONCURRENT_SESSION_COUNT = 4;
+// Concurrent tsx startups on Windows are slow, so each CLI run gets a long budget.
+const CLI_TIMEOUT_MS = 120_000;
+const TEST_TIMEOUT_MS = 240_000;
+const CHILD_EXIT_GRACE_MS = 10_000;
+const DAEMON_CONNECT_TIMEOUT_MS = 2000;
+const DAEMON_REQUEST_TIMEOUT_MS = 5000;
+const SOCKET_GONE_POLL_ATTEMPTS = 50;
+const SOCKET_GONE_POLL_MS = 20;
+
+const children = new Set<ChildProcess>();
+const daemonSockets = new Set<string>();
+const tempRoots = new Set<string>();
+
+function resolveReplPython(): string | null {
+	const candidates = [process.env.PRIME_AGENT_KERNEL_PYTHON, kernelVenvPython(resolveKernelVenvDirSync())].filter(
+		(candidate): candidate is string => Boolean(candidate),
+	);
+	for (const python of candidates) {
+		if (!existsSync(python)) continue;
+		const check = spawnSync(python, ["-c", "import rlm.repl, dill"], { encoding: "utf8" });
+		if (check.status === 0) return python;
+	}
+	return null;
+}
+
+const replPython = resolveReplPython();
+
+function normalizeExecutablePath(path: string): string {
+	const forwardSlashes = path.replaceAll("\\", "/");
+	return process.platform === "win32" ? forwardSlashes.toLowerCase() : forwardSlashes;
+}
+
+function daemonSocketPathFor(root: string): string {
+	if (process.platform === "win32") {
+		return `\\\\.\\pipe\\prime-agent-kernel-concurrency-${process.pid}-${randomUUID().slice(0, 8)}`;
+	}
+	return join(root, "daemon.sock");
+}
+
+async function waitForChildExit(child: ChildProcess): Promise<void> {
+	if (child.exitCode !== null || child.signalCode !== null) {
+		return;
+	}
+	await new Promise<void>((resolveExit) => {
+		const timeout = setTimeout(() => resolveExit(), CHILD_EXIT_GRACE_MS);
+		child.once("exit", () => {
+			clearTimeout(timeout);
+			resolveExit();
+		});
+	});
+}
+
+async function killLiveChildren(): Promise<void> {
+	const liveChildren = [...children];
+	children.clear();
+	for (const child of liveChildren) {
+		if (child.exitCode === null && child.signalCode === null) {
+			child.kill("SIGKILL");
+		}
+	}
+	await Promise.all(liveChildren.map((child) => waitForChildExit(child)));
+}
+
+async function shutdownDaemon(socketPath: string): Promise<void> {
+	const client = new DaemonClient(socketPath);
+	try {
+		await client.connect(DAEMON_CONNECT_TIMEOUT_MS);
+		await client.request({ type: "shutdown" }, DAEMON_REQUEST_TIMEOUT_MS);
+	} catch {
+		// The process may have exited before publishing its socket.
+	} finally {
+		client.close();
+	}
+	for (let attempt = 0; attempt < SOCKET_GONE_POLL_ATTEMPTS && existsSync(socketPath); attempt++) {
+		await new Promise((resolveDelay) => setTimeout(resolveDelay, SOCKET_GONE_POLL_MS));
+	}
+}
+
+afterEach(async () => {
+	await killLiveChildren();
+	for (const socketPath of daemonSockets) {
+		await shutdownDaemon(socketPath);
+	}
+	daemonSockets.clear();
+	for (const root of tempRoots) {
+		await removeTempRoot(root);
+	}
+	tempRoots.clear();
+});
+
+interface CliRunOptions {
+	agentDir: string;
+	cwd: string;
+	environment: NodeJS.ProcessEnv;
+}
+
+interface CliRunResult {
+	code: number | null;
+	signal: NodeJS.Signals | null;
+	stdout: string;
+	stderr: string;
+}
+
+function awaitCliExit(child: ChildProcess, readStderr: () => string): Promise<Pick<CliRunResult, "code" | "signal">> {
+	return new Promise((resolveExit, reject) => {
+		const timeout = setTimeout(() => {
+			child.kill("SIGKILL");
+			reject(new Error(`CLI timed out\n${readStderr()}`));
+		}, CLI_TIMEOUT_MS);
+		child.once("exit", (code, signal) => {
+			clearTimeout(timeout);
+			resolveExit({ code, signal: signal as NodeJS.Signals | null });
+		});
+	});
+}
+
+async function runCli(args: string[], options: CliRunOptions): Promise<CliRunResult> {
+	const child = spawn(process.execPath, [tsxPath, cliPath, ...args], {
+		cwd: options.cwd,
+		env: isolatedDaemonProcessEnv({
+			TSX_TSCONFIG_PATH: repoTsconfigPath,
+			[ENV_AGENT_DIR]: options.agentDir,
+			PI_SKIP_VERSION_CHECK: "1",
+			PRIME_AGENT_INTERNAL_LEGACY_OWNED_WORKER_FRONTEND: "0",
+			PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR: isolatedDaemonRegistryDir(options.agentDir),
+			PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_SELECTED_REGISTRY_DIR: isolatedDaemonRegistryDir(options.agentDir),
+			RLM_DEPTH: "0",
+			...options.environment,
+		}),
+		stdio: ["pipe", "pipe", "pipe"],
+	});
+	children.add(child);
+	let stdout = "";
+	let stderr = "";
+	child.stdout?.on("data", (chunk: Buffer) => {
+		stdout += chunk.toString("utf8");
+	});
+	child.stderr?.on("data", (chunk: Buffer) => {
+		stderr += chunk.toString("utf8");
+	});
+	child.stdin?.end("");
+	const exit = await awaitCliExit(child, () => stderr);
+	children.delete(child);
+	return { ...exit, stdout, stderr };
+}
+
+interface ContentBlock {
+	type: string;
+	text?: string;
+}
+
+interface SessionEvent {
+	type: string;
+	toolName?: string;
+	result?: { content?: ContentBlock[] };
+	message?: { role: string; content?: ContentBlock[] | string };
+}
+
+function parseSessionEvents(stdout: string): SessionEvent[] {
+	return stdout
+		.split("\n")
+		.filter((line) => line.startsWith("{"))
+		.map((line) => JSON.parse(line) as SessionEvent);
+}
+
+function firstText(blocks: ContentBlock[] | string | undefined): string | undefined {
+	if (typeof blocks === "string") return blocks;
+	return blocks?.find((block) => block.type === "text")?.text;
+}
+
+function ipythonResultText(events: SessionEvent[]): string {
+	const toolEnd = events.find((event) => event.type === "tool_execution_end" && event.toolName === "ipython");
+	expect(toolEnd, "ipython tool_execution_end missing from the JSON event stream").toBeDefined();
+	const text = firstText(toolEnd?.result?.content);
+	expect(text, "ipython result has no text block").toBeDefined();
+	return text as string;
+}
+
+function finalAssistantText(events: SessionEvent[]): string {
+	const assistantTexts = events
+		.filter((event) => event.type === "message_end" && event.message?.role === "assistant")
+		.map((event) => firstText(event.message?.content))
+		.filter((text): text is string => text !== undefined);
+	expect(assistantTexts.length, "no assistant text in the JSON event stream").toBeGreaterThan(0);
+	return assistantTexts[assistantTexts.length - 1] as string;
+}
+
+interface ProcessChain {
+	kernelPid: number;
+	kernelOwnerPid: number;
+	python: string;
+	workerPid: number;
+	supervisorPid: number;
+}
+
+function parseProcessChain(stdout: string): ProcessChain {
+	const events = parseSessionEvents(stdout);
+	const kernelText = ipythonResultText(events);
+	const kernelMatch = /KERNEL_PID=(\d+) KERNEL_OWNER_PID=(\d+) PY=(.+)/.exec(kernelText);
+	expect(kernelMatch, `kernel identity missing from ipython result:\n${kernelText}`).not.toBeNull();
+	const workerText = finalAssistantText(events);
+	const workerMatch = /WORKER_PID=(\d+) SUPERVISOR_PID=(\d+)/.exec(workerText);
+	expect(workerMatch, `worker identity missing from the final assistant text:\n${workerText}`).not.toBeNull();
+	return {
+		kernelPid: Number(kernelMatch?.[1]),
+		kernelOwnerPid: Number(kernelMatch?.[2]),
+		python: (kernelMatch?.[3] ?? "").trim(),
+		workerPid: Number(workerMatch?.[1]),
+		supervisorPid: Number(workerMatch?.[2]),
+	};
+}
+
+interface DaemonFixture {
+	agentDir: string;
+	root: string;
+	socketPath: string;
+}
+
+function createDaemonFixture(): DaemonFixture {
+	const root = mkdtempSync(join(tmpdir(), "prime-agent-kernel-concurrency-"));
+	chmodSync(root, 0o700);
+	tempRoots.add(root);
+	const agentDir = join(root, "agent");
+	mkdirSync(agentDir, { recursive: true });
+	const socketPath = daemonSocketPathFor(root);
+	daemonSockets.add(socketPath);
+	return { agentDir, root, socketPath };
+}
+
+async function runKernelSession(fixture: DaemonFixture, index: number): Promise<ProcessChain> {
+	const cwd = join(fixture.root, `cwd-${index}`);
+	mkdirSync(cwd, { recursive: true });
+	const result = await runCli(
+		[
+			"--mode",
+			"json",
+			"--daemon-socket",
+			fixture.socketPath,
+			"--model",
+			"faux/faux",
+			"--extension",
+			fauxExtensionPath,
+			"--no-skills",
+			"--no-prompt-templates",
+			"--no-themes",
+			"--no-context-files",
+			"Run the code",
+		],
+		{
+			agentDir: fixture.agentDir,
+			cwd,
+			environment: { PRIME_AGENT_KERNEL_PYTHON: replPython as string },
+		},
+	);
+	expect(result, `run ${index} failed:\n${result.stderr}`).toMatchObject({ code: 0, signal: null });
+	expect(result.stderr).not.toContain("Timed out waiting for daemon");
+	return parseProcessChain(result.stdout);
+}
+
+async function readSupervisorPidFromHello(socketPath: string): Promise<number | undefined> {
+	const client = new DaemonClient(socketPath);
+	try {
+		await client.connect(DAEMON_CONNECT_TIMEOUT_MS);
+		const hello = await client.waitForHello(DAEMON_REQUEST_TIMEOUT_MS);
+		return hello.supervisorPid;
+	} finally {
+		client.close();
+	}
+}
+
+/**
+ * The CLI launches the supervisor with the registry override env scrubbed, so
+ * the supervisor publishes its owner record in the platform default registry.
+ */
+async function expectSingleSupervisor(fixture: DaemonFixture, chains: ProcessChain[]): Promise<void> {
+	const supervisorPids = new Set(chains.map((chain) => chain.supervisorPid));
+	expect(supervisorPids.size, "workers reported different supervisor pids").toBe(1);
+	const [supervisorPid] = supervisorPids;
+
+	const registryDir = resolveDaemonSupervisorRegistryDir(isolatedDaemonProcessEnv());
+	const owners = (await listDaemonSupervisorProcesses(registryDir)).filter(
+		(owner) => owner.socketPath === normalizeSocketPath(fixture.socketPath),
+	);
+	expect(owners).toHaveLength(1);
+	expect(owners[0]).toMatchObject({
+		pid: supervisorPid,
+		agentDir: canonicalizeDaemonFilesystemPath(fixture.agentDir),
+	});
+
+	await expect(readSupervisorPidFromHello(fixture.socketPath)).resolves.toBe(supervisorPid);
+}
+
+function expectKernelOnOverridePython(chain: ProcessChain): void {
+	expect(chain.kernelPid).toBeGreaterThan(0);
+	expect(chain.kernelOwnerPid).toBe(chain.workerPid);
+	expect(normalizeExecutablePath(chain.python)).toBe(normalizeExecutablePath(replPython as string));
+}
+
+const describeWithKernel = replPython ? describe : describe.skip;
+
+describeWithKernel(
+	"Real-process daemon sessions share one supervisor and get separate kernels",
+	{ tags: ["kernel-heavy"] },
+	() => {
+		it(
+			"runs one session with its kernel on the override python",
+			async () => {
+				const fixture = createDaemonFixture();
+				const chain = await runKernelSession(fixture, 0);
+				expectKernelOnOverridePython(chain);
+				await expectSingleSupervisor(fixture, [chain]);
+			},
+			TEST_TIMEOUT_MS,
+		);
+
+		it(
+			"runs concurrent sessions on one supervisor and one python with a kernel per session",
+			async () => {
+				const fixture = createDaemonFixture();
+				const chains = await Promise.all(
+					Array.from({ length: CONCURRENT_SESSION_COUNT }, (_, index) => runKernelSession(fixture, index)),
+				);
+				for (const chain of chains) {
+					expectKernelOnOverridePython(chain);
+				}
+				expect(new Set(chains.map((chain) => chain.kernelPid)).size).toBe(CONCURRENT_SESSION_COUNT);
+				expect(new Set(chains.map((chain) => chain.workerPid)).size).toBe(CONCURRENT_SESSION_COUNT);
+				await expectSingleSupervisor(fixture, chains);
+			},
+			TEST_TIMEOUT_MS,
+		);
+	},
+);

--- a/prime-agent-runtime/src/rlm/bash.py
+++ b/prime-agent-runtime/src/rlm/bash.py
@@ -893,6 +893,11 @@ def _shell() -> str:
         if not os.path.isabs(override):
             raise ValueError("PRIME_AGENT_BASH_SHELL must be an absolute path")
         return override
+    # The host explains a rejected or missing shell setting here; a PATH
+    # fallback would hide that misconfiguration.
+    issue = os.environ.get("PRIME_AGENT_BASH_SHELL_ISSUE")
+    if issue:
+        raise RuntimeError(f"bash() has no shell: {issue}")
     if not _IS_POSIX:
         # Never consult PATH on Windows: a repo-controlled PATH could supply
         # the shell. The host injects PRIME_AGENT_BASH_SHELL when one exists.

--- a/prime-agent-runtime/src/rlm/bash.py
+++ b/prime-agent-runtime/src/rlm/bash.py
@@ -888,16 +888,17 @@ def bash(command: str) -> BashHandle:
 
 def _shell() -> str:
     # Read per call so env changes made in the REPL apply to later commands.
+    # The host explains a rejected or missing shell setting here. It wins over
+    # any shell path: the host never sets both, so a shell alongside an issue
+    # was inherited from another process and must not bypass the rejection.
+    issue = os.environ.get("PRIME_AGENT_BASH_SHELL_ISSUE")
+    if issue:
+        raise RuntimeError(f"bash() has no shell: {issue}")
     override = os.environ.get("PRIME_AGENT_BASH_SHELL")
     if override:
         if not os.path.isabs(override):
             raise ValueError("PRIME_AGENT_BASH_SHELL must be an absolute path")
         return override
-    # The host explains a rejected or missing shell setting here; a PATH
-    # fallback would hide that misconfiguration.
-    issue = os.environ.get("PRIME_AGENT_BASH_SHELL_ISSUE")
-    if issue:
-        raise RuntimeError(f"bash() has no shell: {issue}")
     if not _IS_POSIX:
         # Never consult PATH on Windows: a repo-controlled PATH could supply
         # the shell. The host injects PRIME_AGENT_BASH_SHELL when one exists.

--- a/prime-agent-runtime/test/test_bash_shell.py
+++ b/prime-agent-runtime/test/test_bash_shell.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import sys
 import unittest
 from unittest import mock
@@ -21,9 +22,18 @@ class ShellResolutionTest(unittest.TestCase):
     def test_absolute_override_wins(self):
         shell = r"C:\Git\bin\bash.exe" if os.name == "nt" else "/opt/bin/bash"
         os.environ["PRIME_AGENT_BASH_SHELL"] = shell
-        os.environ["PRIME_AGENT_BASH_SHELL_ISSUE"] = "ignored when a shell is injected"
 
         self.assertEqual(bash_module._shell(), shell)
+
+    def test_host_issue_beats_inherited_override(self):
+        # A rejected setting must not be bypassed by a shell path inherited
+        # from a parent process that resolved one.
+        issue = "kernelShellPath must be a POSIX shell; bash() cannot run under PowerShell"
+        os.environ["PRIME_AGENT_BASH_SHELL"] = "/bin/bash"
+        os.environ["PRIME_AGENT_BASH_SHELL_ISSUE"] = issue
+
+        with self.assertRaisesRegex(RuntimeError, re.escape(issue)):
+            bash_module._shell()
 
     def test_relative_override_rejected(self):
         os.environ["PRIME_AGENT_BASH_SHELL"] = "bash"

--- a/prime-agent-runtime/test/test_bash_shell.py
+++ b/prime-agent-runtime/test/test_bash_shell.py
@@ -1,0 +1,55 @@
+# Shell resolution for bash(): pure environment-driven tests that run on every
+# platform, unlike test_bash.py, which needs POSIX process groups.
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+import rlm.bash
+
+bash_module = sys.modules["rlm.bash"]
+
+
+class ShellResolutionTest(unittest.TestCase):
+    def setUp(self):
+        self.enterContext(mock.patch.dict(os.environ))
+        os.environ.pop("PRIME_AGENT_BASH_SHELL", None)
+        os.environ.pop("PRIME_AGENT_BASH_SHELL_ISSUE", None)
+
+    def test_absolute_override_wins(self):
+        shell = r"C:\Git\bin\bash.exe" if os.name == "nt" else "/opt/bin/bash"
+        os.environ["PRIME_AGENT_BASH_SHELL"] = shell
+        os.environ["PRIME_AGENT_BASH_SHELL_ISSUE"] = "ignored when a shell is injected"
+
+        self.assertEqual(bash_module._shell(), shell)
+
+    def test_relative_override_rejected(self):
+        os.environ["PRIME_AGENT_BASH_SHELL"] = "bash"
+
+        with self.assertRaises(ValueError):
+            bash_module._shell()
+
+    def test_host_issue_raises_on_every_platform(self):
+        # A rejected shell setting must surface, not fall back to PATH bash.
+        issue = "kernelShellPath does not exist: /opt/missing/bash"
+        os.environ["PRIME_AGENT_BASH_SHELL_ISSUE"] = issue
+        for posix in (True, False):
+            with self.subTest(posix=posix):
+                with mock.patch.object(bash_module, "_IS_POSIX", posix):
+                    with mock.patch.object(bash_module.shutil, "which") as which:
+                        with self.assertRaisesRegex(RuntimeError, issue):
+                            bash_module._shell()
+                        which.assert_not_called()
+
+    def test_windows_without_injected_shell_raises_teaching_error(self):
+        with mock.patch.object(bash_module, "_IS_POSIX", False):
+            with mock.patch.object(bash_module.shutil, "which") as which:
+                with self.assertRaisesRegex(RuntimeError, "PRIME_AGENT_BASH_SHELL"):
+                    bash_module._shell()
+                which.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Windows kernel-shell validation and diagnostics, a real-process daemon-session concurrency test, and corrected Windows docs.

### Kernel shell
- New `kernelShellPath` setting for the Python kernel's `bash()`. Validated: absolute, exists, not PowerShell or `cmd.exe`.
- A POSIX `shellPath` is still used by the kernel. A PowerShell `shellPath` serves the command tool only.
- Invalid settings fail closed: the host injects `PRIME_AGENT_BASH_SHELL_ISSUE` and `bash()` raises that reason on every platform instead of falling back to `PATH` bash.
- Discovery is unchanged: only the two canonical Git Bash paths on Windows, never `PATH`, `%ProgramFiles%`, or `%LOCALAPPDATA%`.
- `prime-agent doctor` prints `Kernel shell: <path> (<source>)` or `Kernel shell: none. <reason>`. `--json` output is unchanged.

### Concurrency test
- `test/suite/daemon-session-kernel-concurrency.test.ts`: spawns the real CLI (`--mode json`) 4 times at once against one isolated agent dir with `PRIME_AGENT_KERNEL_PYTHON` set. Asserts one supervisor (registry owner record and daemon hello), a worker per session, a kernel per worker (`PRIME_AGENT_KERNEL_OWNER_PID` contract), every kernel on the override python.
- Tagged `kernel-heavy`; added to `npm run test:kernel`.
- Fresh managed-venv bootstrap concurrency is not covered here.

### Docs
- `docs/windows.md`: the PowerShell fallback applies to the command tool, not to `bash()` in the kernel. Adds kernel-shell resolution and Windows `bash()` limits (best-effort output drain, cancellation of synchronous code, job containment covers `bash()` children only).
- `docs/settings.md`: `kernelShellPath`.

### Runtime tests
- New `prime-agent-runtime/test/test_bash_shell.py` for shell resolution; runs on Windows. `test_bash.py` imports `resource` and is POSIX-only.

## Verification (Windows 11, Node 22, Python 3.11 override)

```
npm run check
  Checked 1022 files in 1208ms. No fixes applied.
  Installer check passed.

npx tsx ../../node_modules/vitest/dist/cli.js --run test/kernel-bash-shell.test.ts
  Tests  15 passed (15)

npx tsx ../../node_modules/vitest/dist/cli.js --run --no-file-parallelism --tagsFilter kernel-heavy test/suite/daemon-session-kernel-concurrency.test.ts
  Tests  2 passed (2)   Duration 25.45s

uv run python -m unittest discover -s test -p test_bash_shell.py
  Ran 4 tests in 0.003s  OK

prime-agent doctor
  Kernel shell: C:\Program Files\Git\bin\bash.exe (git-bash)
```
